### PR TITLE
Release v0.10.0: add agent-native MCP debugging tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added an agent-native MCP base: safe serialization, exposure audit, request investigation, exception-group investigation, on-demand incident bundles and ticket-text debug briefs.
+- Added an agent-native MCP base: safe serialization, exposure audit, request investigation, exception-group investigation, on-demand incident bundles, ticket-text debug briefs, fix hypotheses and test-plan suggestions.
 
 ### Fixed
 
 - MCP tools now honor `MCP_ENABLED: False` by returning a stable disabled response instead of exposing Orbit entries.
+- The published package now includes `orbit.management` and `orbit.management.commands`, ensuring `python manage.py orbit_mcp` is included in the wheel.
 
 ## [0.9.1] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-25
+
+### Added
+
+- Added an agent-native MCP base: safe serialization, exposure audit, request investigation, exception-group investigation, on-demand incident bundles and ticket-text debug briefs.
+
+### Fixed
+
+- MCP tools now honor `MCP_ENABLED: False` by returning a stable disabled response instead of exposing Orbit entries.
+
 ## [0.9.1] - 2026-06-15
 
 ### Fixed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,6 @@ include CHANGELOG.md
 include CONTRIBUTING.md
 
 recursive-include orbit/templates *
-recursive-include orbit/static *
 recursive-include orbit/migrations *.py
 
 global-exclude __pycache__

--- a/README.md
+++ b/README.md
@@ -225,11 +225,13 @@ Shows the status of every Orbit module:
 
 Django Orbit exposes your telemetry as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server. Connect Claude, Cursor, Windsurf, or any MCP-compatible AI assistant and ask questions directly against your app's live data.
 
+Starting in **v0.10.0**, Orbit is designed as an **AI agent-native debugging layer** for Django: agents can move from ticket or runtime error to evidence, hypotheses, test plan and an incident bundle without needing direct database access or unsafe raw payloads.
+
 **Examples:**
-- *"Why is `/api/orders/` slow?"*
-- *"What exceptions occurred in the last hour?"*
-- *"Find all N+1 patterns in the app"*
-- *"Show me everything that happened during this request"*
+- *"Investigate this ticket: checkout returns 500 payment token rejected."*
+- *"Create an incident bundle for this exception fingerprint."*
+- *"Propose fix hypotheses for request family abc123."*
+- *"Suggest a test plan for the slow checkout request."*
 
 ### Setup
 
@@ -265,6 +267,24 @@ The MCP server launches on-demand when your AI assistant needs it. No extra proc
 | `get_request_detail` | Every event for one request via `family_hash` |
 | `search_entries` | Keyword search across all event types |
 | `get_stats_summary` | Error rate, avg response time, cache hit rate |
+| `audit_mcp_exposure` | Effective agent data exposure policy |
+| `investigate_request` | Request diagnosis with timeline, signals, query analysis and next actions |
+| `investigate_exception_group` | Exception-group blast radius and representative evidence |
+| `create_incident_bundle` | JSON or Markdown handoff bundle from request, fingerprint or ticket text |
+| `build_debug_brief` | Match natural-language ticket text to recent Orbit evidence |
+| `propose_fix_hypotheses` | Ranked fix directions based on captured evidence; does not edit code |
+| `propose_test_plan` | Suggested regression/performance tests for the observed issue |
+
+### Agent-native workflow
+
+```text
+build_debug_brief("checkout returns 500 payment token rejected")
+create_incident_bundle("fingerprint", "<fingerprint>", format="markdown")
+propose_fix_hypotheses("fingerprint", "<fingerprint>")
+propose_test_plan("family_hash", "<family_hash>")
+```
+
+All agent-facing entries go through Orbit's safe serializer: sensitive keys are masked, oversized payloads are replaced with truncation metadata, and `MCP_ENABLED: False` blocks every tool with a stable disabled response.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# 🛰️ Django Orbit
+# Django Orbit
 
-<div align="center">
+**AI agent-native observability and debugging for Django.**
 
-**Satellite Observability for Django**
+Django Orbit is a reusable Django app that records what your application is doing and exposes it through a dashboard and MCP tools. It captures requests, SQL queries, logs, exceptions, cache operations, jobs, storage, mail, permissions and more, then links related events by `family_hash` so humans and AI agents can debug from one coherent timeline.
 
-*A debugging and observability dashboard that orbits your app without touching it.*
+Unlike Django Debug Toolbar, Orbit does not inject HTML into your app. It lives at its own isolated `/orbit/` URL and is designed to observe from a distance without interfering with the host project.
 
 <img width="1312" height="612" alt="Django Orbit Dashboard" src="https://github.com/user-attachments/assets/87528512-b458-4217-8dde-699a23c507ce" />
 
@@ -14,126 +14,123 @@
 [![License](https://img.shields.io/badge/License-MIT-purple?style=flat-square)](LICENSE)
 [![Code Style](https://img.shields.io/badge/Code%20Style-Black-black?style=flat-square)](https://github.com/psf/black)
 
-[📚 Documentation](https://astro-stack.github.io/django-orbit) · [🎮 Try the Demo](#-try-the-demo) · [⭐ Star on GitHub](https://github.com/astro-stack/django-orbit)
+- [Documentation](https://astro-stack.github.io/django-orbit)
+- [Try the demo](#try-the-demo)
+- [MCP / AI assistant setup](#mcp-ai-assistant-setup)
 
-</div>
+## Why Orbit
 
----
+Django teams increasingly debug with AI coding agents, but most local observability tools are built only for humans. Orbit is built for both:
 
-## Table of Contents
+- humans get a focused dashboard for inspecting runtime behavior;
+- agents get structured MCP tools for investigation and handoff;
+- captured events are grouped by request family, so evidence stays connected;
+- agent output is masked, bounded and read-only by default.
 
-- [Why Orbit?](#-why-orbit)
-- [What Orbit tracks](#-what-orbit-tracks)
-- [Installation](#-installation)
-- [Quick Start](#-quick-start)
-- [Try the Demo](#-try-the-demo)
-- [Configuration](#️-configuration)
-- [Dashboards](#-dashboards)
-- [MCP Server — AI Assistant Integration](#-mcp-server--ai-assistant-integration)
-- [Background Job Integrations](#-background-job-integrations)
-- [Health & Plug-and-Play](#-health--plug-and-play)
-- [Storage Backends](#️-storage-backends)
-- [Security](#️-security)
-- [Roadmap](#️-roadmap)
-- [Contributing](#-contributing)
+| Capability | Django Debug Toolbar | Django Orbit |
+|---|---:|---:|
+| Runs outside your app UI | No | Yes |
+| Works with APIs and SPAs | Limited | Yes |
+| Persistent request history | No | Yes |
+| SQL, logs and exceptions together | Partial | Yes |
+| Background jobs and infrastructure events | No | Yes |
+| Agent-native MCP debugging tools | No | Yes |
+| Request-to-fix handoff bundles | No | Yes |
+| Plug-and-play watcher health | No | Yes |
 
----
+Inspired by Laravel Telescope, Spatie Ray and Django Debug Toolbar.
 
-## 🎯 Why Orbit?
-
-Unlike Django Debug Toolbar — which injects HTML into your templates — Django Orbit lives at its own isolated URL (`/orbit/`). It observes your application from a distance, like a satellite, without interfering with it.
-
-| | Django Debug Toolbar | Django Orbit |
-|---|---|---|
-| Template injection | ✅ Yes | ❌ No |
-| Works with APIs / SPAs | ❌ No | ✅ Yes |
-| SQL + logs + exceptions | Partial | ✅ All in one |
-| Background jobs | ❌ | ✅ Celery, RQ, Django-Q |
-| AI assistant integration | ❌ | ✅ MCP Server |
-| Health / module status | ❌ | ✅ |
-
-Inspired by [Laravel Telescope](https://laravel.com/docs/telescope).
-
----
-
-## 📡 What Orbit tracks
+## What Orbit Tracks
 
 | Category | Events |
 |---|---|
-| **HTTP** | Requests, responses, headers, body, status codes |
-| **Database** | SQL queries, slow queries, N+1 detection |
-| **Logging** | All Python `logging` output, any level |
-| **Exceptions** | Full traceback, request context |
-| **Cache** | GET hits/misses, SET, DELETE (any backend) |
-| **Models** | ORM create, update, delete events |
-| **Commands** | `manage.py` executions with exit code |
-| **HTTP Client** | Outgoing requests via `requests` / `httpx` |
-| **Mail** | Sent emails with headers and body |
-| **Signals** | Django signal dispatches |
-| **Background Jobs** | Celery, Django-Q, RQ, APScheduler |
-| **Redis** | GET, SET, DEL, HGET, LPUSH, and more |
-| **Permissions** | Authorization checks, granted/denied |
-| **Transactions** | `atomic()` blocks, commits, rollbacks |
-| **Storage** | File save/open/delete (local + S3) |
+| HTTP | Requests, responses, headers, body, status codes |
+| Database | SQL queries, slow queries, duplicate query / N+1 signals |
+| Logging | Python `logging` output, any level |
+| Exceptions | Exception type, message, traceback and request context |
+| Cache | GET hits/misses, SET, DELETE |
+| Models | ORM create, update and delete events |
+| Commands | `manage.py` executions with exit code |
+| HTTP Client | Outgoing requests via supported clients |
+| Mail | Sent email metadata and body previews |
+| Signals | Django signal dispatches |
+| Jobs | Celery, Django-Q, RQ and APScheduler signals/hooks |
+| Redis | GET, SET, DEL, HGET, LPUSH and more |
+| Permissions | Authorization checks, granted/denied |
+| Transactions | `atomic()` commits and rollbacks |
+| Storage | File save/open/delete operations |
 
-All events are linked by `family_hash`, so you can see every query, log, and exception that occurred within a single request.
+All events can be linked by `family_hash`, which lets you inspect every query, log and exception associated with one request or operation.
 
----
+## What's New in v0.10.0
 
-## 📦 Installation
+Orbit v0.10.0 introduces the agent-native debugging base:
+
+- safe MCP serialization with sensitive-key masking and deterministic truncation;
+- `audit_mcp_exposure` to inspect the effective agent data policy;
+- `investigate_request` for request-family diagnosis;
+- `investigate_exception_group` for exception blast-radius analysis;
+- `create_incident_bundle` for JSON or Markdown handoff bundles;
+- `build_debug_brief` for matching ticket/error text to Orbit evidence;
+- `propose_fix_hypotheses` for ranked fix directions;
+- `propose_test_plan` for regression/performance test suggestions;
+- `MCP_ENABLED: False` now blocks all MCP tools with a stable disabled response.
+
+Telemetry opt-in is not part of v0.10.0. It is intentionally being kept for a separate future release.
+
+## Installation
 
 ```bash
 pip install django-orbit
+```
 
-# With MCP support (AI assistant integration — Claude, Cursor, Copilot)
+For AI assistant integration, install the MCP extra:
+
+```bash
 pip install django-orbit[mcp]
 ```
 
----
+## Quick Start
 
-## 🚀 Quick Start
-
-**1. Add to `INSTALLED_APPS`:**
+Add Orbit to `INSTALLED_APPS`:
 
 ```python
 INSTALLED_APPS = [
     # ...
-    'orbit',
+    "orbit",
 ]
 ```
 
-**2. Add middleware** (early in the list):
+Add the middleware early in the stack:
 
 ```python
 MIDDLEWARE = [
-    'orbit.middleware.OrbitMiddleware',
+    "orbit.middleware.OrbitMiddleware",
     # ...
 ]
 ```
 
-**3. Include URLs:**
+Mount the dashboard URLs:
 
 ```python
-from django.urls import path, include
+from django.urls import include, path
 
 urlpatterns = [
-    path('orbit/', include('orbit.urls')),
+    path("orbit/", include("orbit.urls")),
     # ...
 ]
 ```
 
-**4. Migrate and run:**
+Run migrations and start Django:
 
 ```bash
 python manage.py migrate orbit
 python manage.py runserver
 ```
 
-Visit **http://localhost:8000/orbit/** 🚀
+Visit `http://localhost:8000/orbit/`.
 
----
-
-## 🎮 Try the Demo
+## Try the Demo
 
 ```bash
 git clone https://github.com/astro-stack/django-orbit.git
@@ -143,106 +140,24 @@ python demo.py setup
 python manage.py runserver
 ```
 
-| URL | |
+| URL | Purpose |
 |---|---|
 | `http://localhost:8000/` | Demo app |
-| `http://localhost:8000/orbit/` | Orbit Dashboard |
-| `http://localhost:8000/orbit/stats/` | Stats Dashboard |
-| `http://localhost:8000/orbit/health/` | Health Dashboard |
+| `http://localhost:8000/orbit/` | Orbit dashboard |
+| `http://localhost:8000/orbit/stats/` | Stats dashboard |
+| `http://localhost:8000/orbit/health/` | Watcher health dashboard |
 
----
+## MCP AI Assistant Setup
 
-## ⚙️ Configuration
-
-All settings go in `ORBIT_CONFIG` (or `ORBIT`) in your `settings.py`. Everything has a sensible default — you only need to set what you want to change.
-
-```python
-ORBIT_CONFIG = {
-    'ENABLED': True,                      # set to DEBUG to auto-disable in production
-    'SLOW_QUERY_THRESHOLD_MS': 500,
-    'STORAGE_LIMIT': 1000,                # max entries to keep
-
-    # Watchers — all enabled by default
-    'RECORD_REQUESTS': True,
-    'RECORD_QUERIES': True,
-    'RECORD_LOGS': True,
-    'RECORD_EXCEPTIONS': True,
-    'RECORD_COMMANDS': True,
-    'RECORD_CACHE': True,
-    'RECORD_MODELS': True,
-    'RECORD_HTTP_CLIENT': True,
-    'RECORD_MAIL': True,
-    'RECORD_SIGNALS': True,
-    'RECORD_JOBS': True,
-    'RECORD_REDIS': True,
-    'RECORD_GATES': True,
-    'RECORD_TRANSACTIONS': True,
-    'RECORD_STORAGE': True,
-
-    # Security
-    'AUTH_CHECK': lambda request: request.user.is_staff,
-    'IGNORE_PATHS': ['/orbit/', '/static/', '/media/'],
-
-    # Resilience
-    'WATCHER_FAIL_SILENTLY': True,        # failed watchers log errors but don't crash the app
-}
-```
-
----
-
-## 📊 Dashboards
-
-### Main Dashboard — `/orbit/`
-
-HTMX-powered live feed with 3-second polling. Filter by event type, search by keyword, export to JSON, and click any entry to see its full detail in a slide-over panel.
-
-### Stats Dashboard — `/orbit/stats/`
-
-| Metric | |
-|---|---|
-| **Apdex Score** | User satisfaction index (0–1) |
-| **Percentiles** | P50, P75, P95, P99 response times |
-| **Error Rate** | Failure percentage with trend |
-| **Throughput** | Requests per minute / hour |
-| **Slow Queries** | Count and top offenders |
-| **Cache Hit Rate** | Sparkline chart |
-| **Job Success Rate** | Per-backend breakdown |
-| **Top Denied Permissions** | Authorization audit |
-
-Time range filters: 1h · 6h · 24h · 7d
-
-### Health Dashboard — `/orbit/health/`
-
-Shows the status of every Orbit module:
-
-- 🟢 **Healthy** — working normally
-- 🔴 **Failed** — initialization error (click for full traceback)
-- 🟡 **Disabled** — turned off via config
-
----
-
-## 🤖 MCP Server — AI Assistant Integration
-
-Django Orbit exposes your telemetry as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server. Connect Claude, Cursor, Windsurf, or any MCP-compatible AI assistant and ask questions directly against your app's live data.
-
-Starting in **v0.10.0**, Orbit is designed as an **AI agent-native debugging layer** for Django: agents can move from ticket or runtime error to evidence, hypotheses, test plan and an incident bundle without needing direct database access or unsafe raw payloads.
-
-**Examples:**
-- *"Investigate this ticket: checkout returns 500 payment token rejected."*
-- *"Create an incident bundle for this exception fingerprint."*
-- *"Propose fix hypotheses for request family abc123."*
-- *"Suggest a test plan for the slow checkout request."*
-
-### Setup
+Orbit exposes a local MCP server so AI assistants can query live Django runtime evidence.
 
 ```bash
 pip install django-orbit[mcp]
 ```
 
+Add this server to Claude Desktop, Cursor, Windsurf or any MCP-compatible client:
+
 ```json
-// Claude Desktop → claude_desktop_config.json
-// Cursor → .cursor/mcp.json
-// Windsurf → .windsurfrc
 {
   "mcpServers": {
     "django-orbit": {
@@ -254,28 +169,35 @@ pip install django-orbit[mcp]
 }
 ```
 
-The MCP server launches on-demand when your AI assistant needs it. No extra process to manage.
+The server launches on demand over stdio. It is read-only: it queries `OrbitEntry` data and never mutates the host app.
 
-### Available tools
+### Raw Telemetry Tools
 
-| Tool | What it returns |
+| Tool | Purpose |
 |---|---|
-| `get_recent_requests` | Last N requests with status, path, duration |
-| `get_slow_queries` | SQL queries above threshold, sorted by duration |
-| `get_exceptions` | Exceptions in a time window with full traceback |
-| `get_n1_patterns` | Requests where N+1 duplicate queries were detected |
-| `get_request_detail` | Every event for one request via `family_hash` |
-| `search_entries` | Keyword search across all event types |
-| `get_stats_summary` | Error rate, avg response time, cache hit rate |
-| `audit_mcp_exposure` | Effective agent data exposure policy |
-| `investigate_request` | Request diagnosis with timeline, signals, query analysis and next actions |
-| `investigate_exception_group` | Exception-group blast radius and representative evidence |
-| `create_incident_bundle` | JSON or Markdown handoff bundle from request, fingerprint or ticket text |
-| `build_debug_brief` | Match natural-language ticket text to recent Orbit evidence |
-| `propose_fix_hypotheses` | Ranked fix directions based on captured evidence; does not edit code |
-| `propose_test_plan` | Suggested regression/performance tests for the observed issue |
+| `get_recent_requests` | Last N requests with status, path and duration |
+| `get_slow_queries` | SQL queries above the configured threshold |
+| `get_exceptions` | Exceptions within a time window |
+| `get_n1_patterns` | Requests with duplicate-query evidence |
+| `get_request_detail` | All events for one `family_hash` |
+| `search_entries` | Keyword search across entries |
+| `get_stats_summary` | Error rate, average response time and cache stats |
 
-### Agent-native workflow
+### Agent-Native Tools
+
+| Tool | Purpose |
+|---|---|
+| `audit_mcp_exposure` | Show the effective MCP safety policy |
+| `investigate_request` | Diagnose one request family: timeline, signals, queries, hypotheses and next actions |
+| `investigate_exception_group` | Summarize an exception fingerprint and affected paths |
+| `create_incident_bundle` | Create JSON or Markdown handoff from request, fingerprint or ticket text |
+| `build_debug_brief` | Match natural-language ticket text to recent evidence |
+| `propose_fix_hypotheses` | Rank likely fix directions from captured evidence |
+| `propose_test_plan` | Suggest regression/performance tests for the observed issue |
+
+### Agent Workflow
+
+A typical ticket-to-fix handoff looks like this:
 
 ```text
 build_debug_brief("checkout returns 500 payment token rejected")
@@ -284,46 +206,78 @@ propose_fix_hypotheses("fingerprint", "<fingerprint>")
 propose_test_plan("family_hash", "<family_hash>")
 ```
 
-All agent-facing entries go through Orbit's safe serializer: sensitive keys are masked, oversized payloads are replaced with truncation metadata, and `MCP_ENABLED: False` blocks every tool with a stable disabled response.
+The goal is not for Orbit to edit code. The goal is to give a human or coding agent enough structured, safe evidence to reproduce, test and fix the issue.
 
----
+## Agent Safety
 
-## 🔧 Background Job Integrations
+Agent-facing output goes through Orbit's safe serializer:
 
-| Backend | How |
-|---|---|
-| **Celery** | Via signals (automatic) |
-| **Django-Q** | Via signals (automatic) |
-| **RQ** | Worker monkey-patching (automatic) |
-| **APScheduler** | `register_apscheduler(scheduler)` |
-| **django-celery-beat** | Via model signals (automatic) |
+- sensitive keys are masked using `MASK_KEYS`;
+- payloads can be disabled with `MCP_INCLUDE_PAYLOADS: False`;
+- result sizes are bounded by `MCP_MAX_LIMIT`;
+- oversized payloads are replaced with truncation metadata;
+- `MCP_ENABLED: False` blocks all MCP tools with a stable disabled response.
 
----
-
-## 💚 Health & Plug-and-Play
-
-Each watcher initializes independently. If Celery isn't installed, only the Celery watcher fails — everything else keeps working.
+Example:
 
 ```python
-from orbit import get_watcher_status, get_failed_watchers
-
-get_watcher_status()
-# {'cache': {'installed': True, 'error': None, 'disabled': False}, ...}
-
-get_failed_watchers()
-# {'celery': 'ModuleNotFoundError: No module named celery'}
+ORBIT_CONFIG = {
+    "MCP_ENABLED": True,
+    "MCP_INCLUDE_PAYLOADS": True,
+    "MCP_MAX_LIMIT": 100,
+    "MCP_MAX_PAYLOAD_CHARS": 12000,
+}
 ```
 
----
+## Configuration
 
-## 🗄️ Storage Backends
-
-By default Orbit stores events in your project's `default` database. For production you can route all Orbit writes to a dedicated database so telemetry doesn't compete with application traffic.
+All settings go in `ORBIT_CONFIG` or `ORBIT` in `settings.py`. Most projects can start with defaults.
 
 ```python
-# settings.py
+ORBIT_CONFIG = {
+    "ENABLED": True,
+    "SLOW_QUERY_THRESHOLD_MS": 500,
+    "STORAGE_LIMIT": 1000,
+
+    # Access control. Set this for shared/staging environments.
+    "AUTH_CHECK": lambda request: request.user.is_staff,
+
+    # Keep Orbit from breaking the host app if a watcher fails.
+    "WATCHER_FAIL_SILENTLY": True,
+
+    # MCP / agent exposure controls.
+    "MCP_ENABLED": True,
+    "MCP_INCLUDE_PAYLOADS": True,
+    "MCP_MAX_LIMIT": 100,
+    "MCP_MAX_PAYLOAD_CHARS": 12000,
+}
+```
+
+All watchers can be controlled individually with `RECORD_*` flags such as `RECORD_REQUESTS`, `RECORD_QUERIES`, `RECORD_EXCEPTIONS`, `RECORD_JOBS`, `RECORD_REDIS`, `RECORD_TRANSACTIONS` and `RECORD_STORAGE`.
+
+See the [configuration docs](https://astro-stack.github.io/django-orbit/configuration/) for the full list.
+
+## Dashboard
+
+### Main Dashboard: `/orbit/`
+
+The main dashboard shows a live feed of captured entries. You can filter by type, search, inspect details, export JSON and navigate related entries.
+
+### Stats Dashboard: `/orbit/stats/`
+
+The stats dashboard summarizes request throughput, Apdex, percentiles, error rate, slow queries, cache hit rate, job health and security/permission signals.
+
+### Health Dashboard: `/orbit/health/`
+
+Each watcher registers with Orbit's health system. Failed or missing integrations are shown without taking down the rest of Orbit.
+
+## Storage Backends
+
+By default, Orbit stores entries in the project's default database. For production or heavier usage, route Orbit writes to a dedicated database alias:
+
+```python
 DATABASES = {
-    "default": { ... },
+    "default": {...},
     "orbit": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": BASE_DIR / "orbit.sqlite3",
@@ -340,56 +294,38 @@ ORBIT_CONFIG = {
 python manage.py migrate orbit --database=orbit
 ```
 
-| Backend | Description |
-|---|---|
-| `orbit.backends.database.DatabaseBackend` | **Default** — uses `default` DB, no config needed |
-| `orbit.backends.django_db.DjangoDBBackend` | Dedicated Django database alias |
+## Security Model
 
----
+Orbit is powerful because it records application behavior. Treat access to `/orbit/` and MCP as developer/operator access.
 
-## 🛡️ Security
-
-Restrict access using any callable:
+Recommended defaults for shared environments:
 
 ```python
 ORBIT_CONFIG = {
-    # Staff only
-    'AUTH_CHECK': lambda request: request.user.is_staff,
-
-    # Disable entirely in production
-    'ENABLED': DEBUG,
+    "AUTH_CHECK": lambda request: request.user.is_staff,
+    "MCP_ENABLED": False,  # enable only where local agent access is intended
+    "WATCHER_FAIL_SILENTLY": True,
 }
 ```
 
-Orbit automatically redacts sensitive fields (passwords, tokens, API keys) from request bodies and headers.
+Orbit masks common sensitive keys in request data and agent-facing output, but you should still avoid exposing Orbit dashboards or MCP servers to untrusted users.
 
----
+## Roadmap
 
-## 🗺️ Roadmap
+The v0.10.0 base makes Orbit agent-native. Next tracks:
 
-### What's next
+- OpenTelemetry bridge for interoperability with wider observability tooling;
+- AI/LLM watcher for provider/model/token/tool-call metadata;
+- dashboard affordances for copying incident bundles;
+- GitHub/Jira ticket handoff flows;
+- deeper query and regression analysis.
 
-- **AI Insights engine** — automatic pattern detection and plain-English summaries powered by LLMs
-- **VS Code / Cursor extension** — surface Orbit data in your editor sidebar while you code
-- **Alerting** — Slack, email, and webhook notifications for exceptions and slow requests
-- **Orbit Cloud** — shared team dashboards with historical data retention
+See [Agent-Native Roadmap](https://astro-stack.github.io/django-orbit/roadmap/).
 
----
+## Contributing
 
-## 🤝 Contributing
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+## License
 
-## 📄 License
-
-MIT — see [LICENSE](LICENSE).
-
----
-
-<div align="center">
-
-Inspired by [Laravel Telescope](https://laravel.com/docs/telescope), [Spatie Ray](https://spatie.be/products/ray), and [Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io/).
-
-[⭐ Star on GitHub](https://github.com/astro-stack/django-orbit) · [📚 Documentation](https://astro-stack.github.io/django-orbit) · [🐛 Issues](https://github.com/astro-stack/django-orbit/issues)
-
-</div>
+MIT. See [LICENSE](LICENSE).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,11 +39,13 @@ ORBIT_CONFIG = {
     
     # MCP Server (v0.7.0+)
     'MCP_ENABLED': True,
+    'MCP_INCLUDE_PAYLOADS': True,
+    'MCP_MAX_LIMIT': 100,
+    'MCP_MAX_PAYLOAD_CHARS': 12000,
 
     # Storage Backend (v0.8.0+)
     'STORAGE_BACKEND': 'orbit.backends.database.DatabaseBackend',
     'STORAGE_DB_ALIAS': 'orbit',  # only used by DjangoDBBackend
-
     # Query recording (v0.8.1+)
     'BULK_CREATE_BATCH_SIZE': None,  # set to e.g. 500 to avoid MySQL max_allowed_packet errors
 
@@ -291,7 +293,22 @@ When `False`, watcher failures will surface as exceptions. Useful during develop
 #### `MCP_ENABLED`
 - **Type**: `bool`
 - **Default**: `True`
-- **Description**: Enables the MCP server data exposure.
+- **Description**: Enables MCP data exposure. When `False`, tools return a stable disabled response instead of reading `OrbitEntry` data.
+
+#### `MCP_INCLUDE_PAYLOADS`
+- **Type**: `bool`
+- **Default**: `True`
+- **Description**: Includes masked entry payloads in MCP responses. Set to `False` for metadata-only agent access.
+
+#### `MCP_MAX_LIMIT`
+- **Type**: `int`
+- **Default**: `100`
+- **Description**: Maximum number of entries returned by MCP tools, even when a larger limit is requested.
+
+#### `MCP_MAX_PAYLOAD_CHARS`
+- **Type**: `int`
+- **Default**: `12000`
+- **Description**: Maximum serialized payload size for agent-facing output. Larger payloads are replaced by truncation metadata after masking.
 
 See [MCP Server](mcp.md) for full setup instructions.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Welcome to the Django Orbit documentation. This guide covers installation, confi
 
 ## What is Django Orbit?
 
-Django Orbit is a debugging and observability tool for Django applications. Unlike Django Debug Toolbar, which injects HTML into your templates, Orbit runs on its own isolated URL and provides a modern, reactive dashboard for monitoring your application.
+Django Orbit is an AI agent-native observability and debugging tool for Django applications. Unlike Django Debug Toolbar, which injects HTML into your templates, Orbit runs on its own isolated URL and exposes structured runtime evidence through both a human dashboard and MCP tools for AI assistants.
 
 ### Key Concepts
 
@@ -41,23 +41,34 @@ Django Orbit is a debugging and observability tool for Django applications. Unli
 | Persistent Storage | No | Yes |
 | Historical Data | No | Yes |
 | Stats & Analytics | No | Yes |
-| Modern UI | Basic | Space-themed |
+| Modern UI | Basic | Focused dashboard |
+| Agent-native MCP tools | No | Yes |
+| Ticket-to-fix handoff bundles | No | Yes |
 
-### What's New (Unreleased)
+### What's New in v0.10.0
 
-- **Agent-native debugging roadmap**: high-level MCP investigations, incident bundles, OpenTelemetry export, AI watcher, safety layer and ticket-to-fix handoffs. See [Agent-Native Roadmap](roadmap.md).
+- **Agent-native debugging base**: Orbit now exposes high-level MCP tools that help AI assistants move from ticket or runtime error to evidence, fix hypotheses, test plans and incident bundles.
+- **Safe MCP serialization**: agent-facing output masks sensitive keys, can omit payloads, bounds result sizes and truncates oversized payloads deterministically.
+- **Request and exception investigation**: `investigate_request` and `investigate_exception_group` summarize timelines, related signals, likely causes and next actions.
+- **Ticket-to-evidence workflow**: `build_debug_brief`, `create_incident_bundle`, `propose_fix_hypotheses` and `propose_test_plan` support daily developer and coding-agent workflows.
+- **MCP kill switch**: `MCP_ENABLED: False` now blocks all MCP tools with a stable disabled response.
 
-- **Dashboard UX overhaul**: a calmer, minimal redesign with a **grouped, collapsible
-  sidebar** (Core / Infrastructure / Application), a standalone **All Events**, and a
-  compact **metrics strip** that leaves more room for the feed. See [Dashboard](dashboard.md).
-- **Detail panel navigation**: move between entries with **`j`/`k`**, close with **`Esc`**,
-  plus prev/next buttons and a position indicator.
-- **First-run onboarding** tour, reopenable from the **?** button.
-- **Faster Stats page**: the headline renders instantly and heavy sections load lazily,
-  removing the old SQLite "database is locked" workaround. See [Stats](stats.md).
-- **Design system**: tokens, components and principles are documented in
-  [`DESIGN.md`](https://github.com/astro-stack/django-orbit/blob/main/DESIGN.md).
+Telemetry opt-in is intentionally not included in v0.10.0. It is planned for a separate future release.
 
+### What's New in v0.9.1
+
+- **MCP server runtime fix**: `orbit_mcp` now works correctly with FastMCP's async loop by allowing Django's synchronous ORM in this local stdio server context.
+- **Exception grouping fix**: exceptions without a fingerprint are no longer hidden from the grouped Exceptions view.
+
+### What's New in v0.9.0
+
+- **Sensitive-data masking**: recursive, case-insensitive masking for tokens, passwords, API keys, cookies and related values.
+- **Query EXPLAIN**: inspect query plans from the query detail panel.
+- **Request waterfall**: see request query timing as a timeline.
+- **Tags and tag search**: attach and filter entries by operational tags.
+- **Exception grouping**: group identical exceptions by fingerprint.
+- **Dashboard redesign**: grouped sidebar, All Events, compact KPI strip, keyboard navigation and onboarding.
+- **Faster Stats page**: heavy sections now lazy-load.
 ### What's New in v0.8.1
 
 - **HTML Email Preview**: Emails sent with `EmailMultiAlternatives` now show a **Plain text / HTML preview** tab switcher in the dashboard. The HTML body renders in a sandboxed iframe — great for testing email templates. See [Email Preview](dashboard.md#mail-html-preview).

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,10 +14,11 @@ Welcome to the Django Orbit documentation. This guide covers installation, confi
 6. [Stats Dashboard](stats.md)
 7. [MCP Server](mcp.md) ✨ **New in v0.7.0**
 8. [Storage Backends](storage-backends.md) ✨ **New in v0.8.0**
-9. [API Reference](api.md)
-10. [Customization](customization.md)
-11. [Security](security.md)
-12. [Troubleshooting](troubleshooting.md)
+9. [Agent-Native Roadmap](roadmap.md)
+10. [API Reference](api.md)
+11. [Customization](customization.md)
+12. [Security](security.md)
+13. [Troubleshooting](troubleshooting.md)
 
 ## What is Django Orbit?
 
@@ -43,6 +44,8 @@ Django Orbit is a debugging and observability tool for Django applications. Unli
 | Modern UI | Basic | Space-themed |
 
 ### What's New (Unreleased)
+
+- **Agent-native debugging roadmap**: high-level MCP investigations, incident bundles, OpenTelemetry export, AI watcher, safety layer and ticket-to-fix handoffs. See [Agent-Native Roadmap](roadmap.md).
 
 - **Dashboard UX overhaul**: a calmer, minimal redesign with a **grouped, collapsible
   sidebar** (Core / Infrastructure / Application), a standalone **All Events**, and a

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -69,7 +69,7 @@ The MCP server launches on-demand using stdio transport — no extra process to 
 
 ## Available Tools
 
-The MCP server exposes 7 tools to your AI assistant:
+The MCP server exposes raw telemetry tools plus higher-level agentic investigation tools to your AI assistant:
 
 | Tool | What it returns |
 |------|----------------|
@@ -80,6 +80,33 @@ The MCP server exposes 7 tools to your AI assistant:
 | `get_request_detail` | Every event for one request via `family_hash` |
 | `search_entries` | Keyword search across all event types |
 | `get_stats_summary` | Error rate, avg response time, cache hit rate |
+| `audit_mcp_exposure` | Effective MCP safety policy: payload inclusion, masking and limits |
+| `investigate_request` | Diagnosis for one `family_hash`: timeline, signals, queries, hypotheses and next actions |
+| `investigate_exception_group` | Blast-radius summary for one exception fingerprint |
+| `create_incident_bundle` | On-demand JSON handoff bundle from a request, fingerprint or ticket text |
+| `build_debug_brief` | Match natural-language ticket/error text to recent Orbit evidence |
+| `propose_fix_hypotheses` | Ranked fix directions from captured evidence; does not edit code |
+| `propose_test_plan` | Suggested regression/performance tests for the observed issue |
+
+
+## Agentic Debugging Workflow
+
+Use the high-level tools when you want the assistant to move from symptom to evidence instead of browsing raw rows.
+
+```text
+build_debug_brief("checkout returns 500 payment token rejected")
+create_incident_bundle("fingerprint", "<fingerprint-from-brief>", format="markdown")
+propose_fix_hypotheses("fingerprint", "<fingerprint-from-brief>")
+propose_test_plan("family_hash", "<family_hash>")
+investigate_exception_group("<fingerprint>")
+investigate_request("<family_hash>")
+```
+
+Incident bundles are generated on demand from current `OrbitEntry` data. They are not persisted. Each bundle includes primary evidence, a safety report, recommended next actions and tool suggestions for deeper investigation.
+
+## Agent Safety
+
+All MCP entry output goes through Orbit's agent-safe serializer. It masks sensitive keys using `MASK_KEYS`, can omit payloads entirely, and replaces oversized payloads with deterministic truncation metadata. Use `audit_mcp_exposure` to verify the effective policy before sharing an MCP session with an assistant.
 
 ## Example Prompts
 
@@ -115,7 +142,7 @@ This starts the server in stdio mode. It reads JSON-RPC messages from stdin and 
 
 ## How It Works
 
-The `orbit_mcp` management command calls `create_mcp_server()` from `orbit/mcp_server.py`, which builds a `FastMCP` instance with the 7 tools. Each tool queries `OrbitEntry` directly from your Django database.
+The `orbit_mcp` management command calls `create_mcp_server()` from `orbit/mcp_server.py`, which builds a `FastMCP` instance with the raw telemetry and agentic investigation tools. Each tool queries `OrbitEntry` directly from your Django database.
 
 The server is stateless and read-only — it never modifies your data.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -2,8 +2,8 @@
 
 Django Orbit exposes your app's telemetry as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server. Connect Claude, Cursor, Windsurf, or any MCP-compatible AI assistant and ask questions directly against your app's live observability data.
 
-!!! tip "New in v0.7.0"
-    The MCP server is available starting from `django-orbit[mcp]`.
+!!! tip "New in v0.10.0"
+    Orbit now includes agent-native MCP investigation tools for request diagnosis, exception groups, incident bundles, fix hypotheses and test plans.
 
 ## Installation
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,78 +1,111 @@
 # Publishing Django Orbit
 
-## Prerequisites
+This is the release checklist for publishing Django Orbit to GitHub, PyPI and the public MkDocs site.
 
-1. Create accounts:
-   - [PyPI](https://pypi.org/account/register/) (production)
-   - [TestPyPI](https://test.pypi.org/account/register/) (testing)
+## Release Order
 
-2. Install build tools:
-   ```bash
-   pip install build twine
-   ```
+1. Merge the release PR into `main`.
+2. Pull the final `main` locally and confirm the version.
+3. Run the full test suite.
+4. Build the package from a clean `dist/`.
+5. Verify the built wheel and sdist.
+6. Publish to PyPI.
+7. Create the GitHub release and tag.
+8. Deploy the documentation site.
+9. Verify PyPI, GitHub release, docs and a fresh install.
 
-## Build the Package
+## Preflight
 
 ```bash
-# Clean previous builds
+git checkout main
+git pull --ff-only
+python -m pytest --tb=short -q
+python -m pip install build twine
+```
+
+Confirm these files are aligned before publishing:
+
+- `pyproject.toml` project version
+- `orbit/__init__.py` `__version__`
+- `CHANGELOG.md` release section
+- `README.md` package landing page
+- `docs/` and `mkdocs.yml` for user-visible changes
+
+## Build
+
+Clean old artifacts and build fresh distributions:
+
+```bash
 rm -rf dist/ build/ *.egg-info/
-
-# Build
 python -m build
+python -m twine check dist/*
 ```
 
-This creates:
-- `dist/django_orbit-0.1.0.tar.gz` (source)
-- `dist/django_orbit-0.1.0-py3-none-any.whl` (wheel)
+Expected files for version `X.Y.Z`:
 
-## Test on TestPyPI First
-
-```bash
-# Upload to TestPyPI
-twine upload --repository testpypi dist/*
-
-# Test installation
-pip install --index-url https://test.pypi.org/simple/ django-orbit
-```
+- `dist/django_orbit-X.Y.Z.tar.gz`
+- `dist/django_orbit-X.Y.Z-py3-none-any.whl`
 
 ## Publish to PyPI
 
 ```bash
-# Upload to production PyPI
-twine upload dist/*
+python -m twine upload dist/django_orbit-X.Y.Z*
 ```
 
-You'll be prompted for your PyPI username and password (or API token).
+Use a PyPI project token when prompted:
 
-## Using API Tokens (Recommended)
-
-1. Go to https://pypi.org/manage/account/token/
-2. Create a token for this project
-3. Use with twine:
-   ```bash
-   twine upload dist/* -u __token__ -p pypi-YOUR_TOKEN_HERE
-   ```
-
-Or create `~/.pypirc`:
-```ini
-[pypi]
-username = __token__
-password = pypi-YOUR_TOKEN_HERE
-```
-
-## After Publishing
-
-Test the installation:
 ```bash
-pip install django-orbit
+python -m twine upload dist/django_orbit-X.Y.Z* -u __token__ -p pypi-...
 ```
 
-## Version Updates
+## GitHub Release
 
-1. Update version in `orbit/__init__.py`
-2. Update CHANGELOG.md
-3. Rebuild and upload:
-   ```bash
-   python -m build
-   twine upload dist/*
-   ```
+Create a GitHub release from the same version and changelog section:
+
+```bash
+gh release create vX.Y.Z --target main --title "vX.Y.Z" --notes-file RELEASE_NOTES.md
+```
+
+The release notes should summarize:
+
+- highlights for users;
+- compatibility or migration notes;
+- security/safety changes;
+- test plan used for the release.
+
+## Deploy Documentation
+
+```bash
+mkdocs build --strict
+mkdocs gh-deploy
+```
+
+Documentation must be deployed from the same code that was released.
+
+## Post-Publish Verification
+
+Check the public package page:
+
+```bash
+python -m pip index versions django-orbit
+```
+
+Test a clean install in a temporary environment:
+
+```bash
+python -m venv .venv-release-check
+.venv-release-check\Scripts\python -m pip install --upgrade pip
+.venv-release-check\Scripts\python -m pip install "django-orbit[mcp]==X.Y.Z"
+.venv-release-check\Scripts\python -c "import orbit; print(orbit.__version__)"
+```
+
+Verify these public URLs:
+
+- PyPI: `https://pypi.org/project/django-orbit/`
+- GitHub release: `https://github.com/astro-stack/django-orbit/releases/tag/vX.Y.Z`
+- Docs: `https://astro-stack.github.io/django-orbit/`
+- MCP docs: `https://astro-stack.github.io/django-orbit/mcp/`
+
+## If Upload Fails
+
+PyPI versions are immutable. If `X.Y.Z` was already uploaded, bump to the next patch version, update changelog/version files, rebuild and upload again.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,251 @@
+# Roadmap: Agent-Native Debugging
+
+Django Orbit should evolve from a Django debugging dashboard into an agent-native observability layer: a local, privacy-conscious system that gives humans and AI agents enough structured context to move from ticket or error to root-cause hypothesis and proposed fix.
+
+## Direction
+
+The future debugging workflow is likely to be hybrid:
+
+- humans use the dashboard for inspection, trust-building and quick triage;
+- agents use MCP tools, incident bundles and structured traces for investigation;
+- coding agents consume the same context to propose patches, tests and pull requests;
+- OpenTelemetry compatibility keeps Orbit interoperable with the wider observability ecosystem.
+
+Orbit's differentiator should be Django-native context: request lifecycle, ORM behavior, middleware, templates, cache, storage, mail, auth/gates, jobs, signals and settings-aware safety boundaries.
+
+## Track A: High-Level MCP Tools
+
+Current MCP tools expose useful raw slices. The next generation should expose investigation primitives that answer developer and agent questions directly.
+
+### Request and Endpoint Investigation
+
+| Tool | Purpose |
+|------|---------|
+| `investigate_request(family_hash)` | Return a complete diagnosis for one request: request summary, child events, slow spans, duplicate queries, exceptions, logs and likely causes. |
+| `investigate_endpoint(path, method=None, hours=24)` | Summarize health for an endpoint across recent traffic: latency, error rate, slow queries, top exception groups and regressions. |
+| `compare_endpoint_windows(path, baseline_hours=24, current_hours=1)` | Compare current endpoint behavior against a prior window to detect regressions. |
+| `find_slowest_endpoints(hours=24, limit=10)` | Rank endpoints by p95 or average duration with query and exception context. |
+| `find_erroring_endpoints(hours=24, limit=10)` | Rank endpoints by error rate and show representative requests. |
+| `summarize_request_family(family_hash)` | Compact, agent-friendly summary of one family without full payload noise. |
+| `get_request_timeline(family_hash)` | Return ordered spans/events suitable for RCA and timeline rendering. |
+| `find_related_requests(family_hash, limit=10)` | Find similar requests by path, exception fingerprint, tags or duplicate-query signature. |
+| `explain_status_code_spike(status_code, hours=24)` | Identify paths and fingerprints driving a spike in 4xx/5xx responses. |
+
+### Exception and Error Intelligence
+
+| Tool | Purpose |
+|------|---------|
+| `investigate_exception_group(fingerprint)` | Return representative traceback, frequency, affected paths, first/last seen and likely owner surface. |
+| `summarize_exception_groups(hours=24)` | Group exceptions by fingerprint and rank by recency, frequency and blast radius. |
+| `find_new_exception_groups(hours=24, baseline_hours=168)` | Detect exceptions not seen in the baseline period. |
+| `find_regressed_exception_groups(hours=24, baseline_hours=168)` | Detect exception groups whose frequency increased materially. |
+| `get_exception_repro_context(entry_id)` | Return request method/path, payload shape, user/auth hints, related logs and DB/cache events needed to reproduce. |
+| `trace_exception_to_request(entry_id)` | Walk from exception to parent request and adjacent logs/queries/jobs. |
+| `classify_exception(entry_id)` | Classify likely category: validation, auth, database, migration, external service, timeout, template, settings, code bug. |
+| `suggest_exception_fix(entry_id)` | Produce a bounded hypothesis and candidate code areas, not an automatic patch. |
+
+### Database and ORM Analysis
+
+| Tool | Purpose |
+|------|---------|
+| `investigate_slow_query(entry_id)` | Explain one slow query with request context, duplicates, stack caller and optional EXPLAIN summary. |
+| `find_n_plus_one_candidates(hours=24)` | Rank endpoints/requests with duplicate-query evidence. |
+| `explain_n_plus_one(family_hash)` | Identify repeated SQL shapes, likely model relation and suggested `select_related` / `prefetch_related`. |
+| `find_duplicate_query_signatures(hours=24)` | Group repeated SQL fingerprints globally. |
+| `find_query_regressions(hours=24, baseline_hours=168)` | Detect query count or duration increases by endpoint. |
+| `find_missing_indexes_candidates(hours=24)` | Use slow query patterns and EXPLAIN output to identify likely missing indexes. |
+| `summarize_db_load(hours=24)` | Return query count, slow count, duplicate count, top tables if inferable and worst endpoints. |
+| `get_query_callsite(entry_id)` | Return captured Python stack/caller context for the query. |
+
+### Logs, Cache, Storage, Mail and Jobs
+
+| Tool | Purpose |
+|------|---------|
+| `investigate_log(entry_id)` | Tie a warning/error log to request/job context and nearby events. |
+| `find_warning_clusters(hours=24)` | Group warnings by logger/message shape and affected paths. |
+| `analyze_cache_efficiency(hours=24)` | Cache hit/miss ratios by operation/key prefix if safe. |
+| `find_cache_miss_spikes(hours=24)` | Identify endpoints or code paths with elevated misses. |
+| `investigate_job_failure(entry_id)` | Summarize failed job, exception/log context and related DB/cache/external calls. |
+| `summarize_jobs(hours=24)` | Job success/failure counts, slow jobs and top failure fingerprints. |
+| `investigate_storage_error(entry_id)` | Explain storage failures with backend, operation and safe path metadata. |
+| `investigate_mail_failure(entry_id)` | Summarize mail send failures, backend and safe recipient metadata. |
+| `find_external_service_failures(hours=24)` | Group HTTP client failures/timeouts by host and endpoint. |
+
+### Security and Privacy-Aware Debugging
+
+| Tool | Purpose |
+|------|---------|
+| `find_authz_denials(hours=24)` | Summarize gate/permission denials by permission, user class and endpoint. |
+| `investigate_permission_denial(entry_id)` | Tie a denial to request context and related logs. |
+| `audit_mcp_exposure()` | Report MCP config, masking config and which tools can expose what classes of data. |
+| `preview_masked_entry(entry_id)` | Show exactly what an agent would receive after masking. |
+| `find_sensitive_payload_risks(limit=20)` | Identify entries whose keys look sensitive and confirm masking behavior. |
+| `list_agent_safe_fields(entry_type)` | Return the allowlisted fields exported to MCP/incident bundles. |
+
+### Ticket-to-Diagnosis Tools
+
+| Tool | Purpose |
+|------|---------|
+| `investigate_ticket(text, hours=72)` | Parse a ticket/error report and search Orbit for matching paths, messages, fingerprints and tags. |
+| `match_error_text(text, hours=72)` | Match pasted stack traces or user reports to exception groups and logs. |
+| `build_debug_brief(query, hours=72)` | Generate a concise brief for a human or coding agent from a natural-language problem. |
+| `find_recent_changes_context(path=None)` | Return Orbit-side evidence useful to compare against recent code changes, without reading git. |
+| `propose_reproduction_steps(entry_id)` | Convert request/error context into likely repro steps and test targets. |
+| `propose_test_plan(entry_id)` | Suggest unit/integration/E2E tests that would cover the failure. |
+| `propose_fix_hypotheses(entry_id)` | Produce ranked hypotheses with confidence, evidence and files/surfaces likely involved. |
+| `create_agent_handoff_bundle(entry_id_or_query)` | Produce a compact JSON/Markdown bundle for Codex/Cursor/Claude. |
+
+### Daily Developer Workflows
+
+| Tool | Purpose |
+|------|---------|
+| `daily_health_brief(hours=24)` | Morning digest: error groups, slow endpoints, N+1s, job failures, new warnings. |
+| `what_changed_in_orbit(hours=24)` | Human-friendly summary of notable runtime behavior changes. |
+| `triage_top_issues(hours=24, limit=10)` | Rank issues by severity, recency, frequency and blast radius. |
+| `find_flaky_failures(days=7)` | Detect intermittent exception/job/log patterns. |
+| `list_open_debug_threads(hours=24)` | Return unresolved-looking issue clusters with latest evidence. |
+| `suggest_next_debug_action(issue_id_or_entry_id)` | Recommend the next investigation step based on missing evidence. |
+| `generate_pr_context(entry_id_or_group)` | Create PR-ready context: problem, evidence, suspected cause, test plan. |
+| `generate_release_risk_brief(hours=24)` | Before release: current errors, slow paths, new exception groups and safety warnings. |
+
+## Track B: Incident Bundles
+
+Incident Bundles are portable evidence packages generated from a request, exception group, endpoint, ticket text or natural-language query. They should be small enough for agents, structured enough for automation and readable enough for humans.
+
+### Bundle Sources
+
+- `family_hash` for a single request lifecycle;
+- exception `fingerprint` for grouped errors;
+- endpoint path/method for route-level behavior;
+- raw ticket text or pasted traceback;
+- tag, query or time window.
+
+### Bundle Contents
+
+Each bundle should include:
+
+- metadata: bundle id, generated at, Orbit version, time window, source type;
+- primary evidence: request summary, exception summary, endpoint stats or matched ticket terms;
+- timeline: ordered events with relative offsets;
+- query analysis: slow queries, duplicate signatures, callsites and EXPLAIN summaries when available;
+- logs: warning/error logs near the event, grouped by logger/message shape;
+- related systems: cache, jobs, mail, storage, Redis, HTTP client, gates;
+- safety report: masking status, omitted fields, payload truncation and MCP exposure policy;
+- hypotheses: ranked causes with supporting evidence and confidence;
+- suggested next actions: reproduce, inspect file/surface, add test, check config, add index, etc.;
+- agent handoff: compact JSON plus Markdown brief.
+
+### Bundle Formats
+
+- `incident_bundle.json` for agents and automation;
+- `incident_bundle.md` for tickets, PRs and humans;
+- optional zipped export for sharing with maintainers;
+- future: OTLP trace export for OpenTelemetry-compatible backends.
+
+### MCP Tools for Bundles
+
+- `create_incident_bundle(source_type, source_id_or_text, hours=72)`
+- `get_incident_bundle(bundle_id)`
+- `list_recent_incident_bundles(limit=20)`
+- `export_incident_bundle(bundle_id, format="json|markdown")`
+- `redact_incident_bundle(bundle_id, policy="agent_safe")`
+
+### Storage Model
+
+Start without a new table: generate bundles on demand from `OrbitEntry` and return them directly. Add persisted bundles later only if users need sharing, comments or issue tracking.
+
+## Track C: OpenTelemetry Bridge
+
+Add OpenTelemetry as an interoperability lane, not as a replacement for Orbit's Django-native storage.
+
+Possible milestones:
+
+1. `orbit.exporters.opentelemetry` module that converts `OrbitEntry` objects into OTEL-like spans/events.
+2. Config keys: `OTEL_EXPORT_ENABLED`, `OTEL_EXPORT_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_HEADERS`, `OTEL_SAMPLE_RATE`.
+3. Map `family_hash` to `trace_id` and child entries to spans/events.
+4. Map SQL/cache/http_client/job/mail/storage events to semantic attributes where stable.
+5. Add GenAI/LLM attributes when the AI watcher ships.
+6. Provide `python manage.py orbit_export_otel --since ...` for batch export.
+7. Optional live export hook with strict fail-silent behavior.
+
+## Track D: AI and LLM Watcher
+
+Capture AI application behavior for Django apps that call LLM providers or agent frameworks.
+
+Initial surfaces:
+
+- OpenAI Python SDK;
+- Anthropic Python SDK;
+- LangChain / LangGraph callbacks;
+- LiteLLM if present;
+- HTTP fallback for known provider hosts.
+
+Events should capture only safe metadata by default:
+
+- provider, model, operation, status;
+- latency, retries, timeout/error type;
+- token counts and estimated cost when available;
+- tool call names, not raw arguments by default;
+- prompt/completion capture disabled by default and guarded by explicit config;
+- request family correlation so LLM calls appear inside the Django request timeline.
+
+Possible config:
+
+```python
+ORBIT_CONFIG = {
+    "RECORD_AI": True,
+    "AI_CAPTURE_PROMPTS": False,
+    "AI_CAPTURE_COMPLETIONS": False,
+    "AI_CAPTURE_TOOL_ARGS": False,
+    "AI_MASK_KEYS": ["password", "token", "secret"],
+}
+```
+
+## Track E: Agent Safety Layer
+
+Before Orbit becomes deeply agentic, it needs explicit data boundaries.
+
+Milestones:
+
+1. Central `agent_safe_serialize_entry(entry)` used by MCP and bundles.
+2. Default field allowlists by entry type.
+3. Payload size caps and deterministic truncation metadata.
+4. MCP-level config: `MCP_ENABLED`, `MCP_ALLOWED_TOOLS`, `MCP_DENIED_TOOLS`, `MCP_MAX_LIMIT`, `MCP_INCLUDE_PAYLOADS`.
+5. `audit_mcp_exposure()` tool.
+6. Masking preview in dashboard and MCP.
+7. Optional per-environment profiles: `local`, `staging`, `production`.
+
+## Track F: From Error to Fix Hypothesis
+
+Orbit should not directly edit code. It should produce evidence-rich handoffs that coding agents can use.
+
+Workflow:
+
+1. Developer pastes a ticket, traceback or endpoint complaint.
+2. Orbit matches it to entries, exception groups, endpoints or related logs.
+3. Orbit creates an Incident Bundle.
+4. Orbit ranks hypotheses and suggests repro/test plan.
+5. A coding agent consumes the bundle, inspects the repo, writes tests, proposes a fix and references the evidence.
+6. Orbit can later verify whether the runtime symptom disappeared.
+
+MCP sequence example:
+
+```text
+investigate_ticket("Users get 500 on checkout")
+create_incident_bundle("ticket", "Users get 500 on checkout")
+propose_fix_hypotheses(bundle_id)
+propose_test_plan(bundle_id)
+generate_pr_context(bundle_id)
+```
+
+## Near-Term Priority
+
+The pragmatic next PR sequence:
+
+1. Add `agent_safe_serialize_entry()` and make existing MCP tools use it.
+2. Add `investigate_request(family_hash)`.
+3. Add `investigate_exception_group(fingerprint)`.
+4. Add `create_incident_bundle(...)` as on-demand JSON.
+5. Add `build_debug_brief(query, hours=72)`.
+6. Add OpenTelemetry export design doc and config stub.
+7. Add AI watcher behind conservative defaults.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - Stats Dashboard: stats.md
     - MCP Server: mcp.md
     - Storage Backends: storage-backends.md
+    - Agent-Native Roadmap: roadmap.md
     - Scheduled Cleanup: scheduling.md
     - Running Demo: running-demo.md
   - Reference:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Django Orbit
-site_description: Satellite Observability for Django - A modern debugging and telemetry tool
+site_description: AI agent-native observability and debugging for Django
 site_url: https://astro-stack.github.io/django-orbit
 repo_url: https://github.com/astro-stack/django-orbit
 repo_name: astro-stack/django-orbit

--- a/orbit/__init__.py
+++ b/orbit/__init__.py
@@ -1,9 +1,9 @@
 """
-Django Orbit - Satellite Observability for Django
+Django Orbit - AI agent-native observability for Django
 
 A modern debugging and observability tool that orbits your Django application
 without touching it. Unlike Django Debug Toolbar, Orbit lives in its own
-isolated URL with a completely separate, reactive interface.
+isolated URL and exposes structured evidence through a dashboard and MCP tools.
 """
 
 __version__ = "0.10.0"

--- a/orbit/__init__.py
+++ b/orbit/__init__.py
@@ -6,7 +6,7 @@ without touching it. Unlike Django Debug Toolbar, Orbit lives in its own
 isolated URL with a completely separate, reactive interface.
 """
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"
 __author__ = "Django Orbit Contributors"
 
 default_app_config = "orbit.apps.OrbitConfig"

--- a/orbit/agentic.py
+++ b/orbit/agentic.py
@@ -602,4 +602,3 @@ def propose_test_plan(source_type: str, source_value: str, hours: int = 72) -> d
         "recommended_tests": tests,
         "safety": {"does_not_modify_code": True, "uses_masked_payloads": True},
     }
-

--- a/orbit/agentic.py
+++ b/orbit/agentic.py
@@ -1,0 +1,605 @@
+"""
+Agent-native investigation helpers for Django Orbit.
+
+This module is the safety boundary for MCP tools and incident bundles. Keep all
+agent-facing payload serialization here so masking, truncation and summaries stay
+consistent across human and AI workflows.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from typing import Any, Iterable
+
+from django.db.models import Count, Q
+from django.utils import timezone
+
+from orbit.conf import get_config
+from orbit.models import OrbitEntry
+from orbit.utils import mask_sensitive_data, parse_tags, serialize_for_json
+
+HIGH_LEVEL_TOOLS = [
+    "audit_mcp_exposure",
+    "investigate_request",
+    "investigate_exception_group",
+    "create_incident_bundle",
+    "build_debug_brief",
+    "propose_fix_hypotheses",
+    "propose_test_plan",
+]
+
+DEFAULT_MAX_PAYLOAD_CHARS = 12000
+DEFAULT_MAX_EVENTS = 100
+
+
+def _config_int(name: str, default: int) -> int:
+    value = get_config().get(name, default)
+    try:
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _config_bool(name: str, default: bool) -> bool:
+    return bool(get_config().get(name, default))
+
+
+def _json_size(value: Any) -> int:
+    return len(json.dumps(value, default=str, separators=(",", ":")))
+
+
+def _truncate_payload(payload: Any, max_payload_chars: int) -> tuple[Any, bool, int]:
+    """Return a JSON-safe payload bounded by a deterministic character budget."""
+    safe_payload = serialize_for_json(mask_sensitive_data(payload or {}))
+    size = _json_size(safe_payload)
+    if size <= max_payload_chars:
+        return safe_payload, False, size
+
+    # Keep structure predictable for agents and avoid leaking omitted content.
+    metadata = {
+        "_truncated": True,
+        "_original_size_chars": size,
+        "_max_size_chars": max_payload_chars,
+    }
+    if "***HIDDEN***" in json.dumps(safe_payload, default=str):
+        metadata["_redaction_marker"] = "***HIDDEN***"
+    return metadata, True, size
+
+
+def _safe_limit(limit: int | None, default: int = 20) -> int:
+    configured_max = _config_int("MCP_MAX_LIMIT", 100)
+    if limit is None:
+        limit = default
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        limit = default
+    return max(1, min(limit, configured_max))
+
+
+def agent_safe_serialize_entry(
+    entry: OrbitEntry,
+    *,
+    include_payload: bool | None = None,
+    max_payload_chars: int | None = None,
+) -> dict[str, Any]:
+    """
+    Serialize an OrbitEntry for agent consumption.
+
+    The serializer always masks sensitive keys before output and annotates payload
+    truncation/omission so agents know when evidence is incomplete.
+    """
+    if include_payload is None:
+        include_payload = _config_bool("MCP_INCLUDE_PAYLOADS", True)
+    if max_payload_chars is None:
+        max_payload_chars = _config_int("MCP_MAX_PAYLOAD_CHARS", DEFAULT_MAX_PAYLOAD_CHARS)
+
+    data: dict[str, Any] = {
+        "id": str(entry.id),
+        "type": entry.type,
+        "summary": entry.summary,
+        "duration_ms": entry.duration_ms,
+        "family_hash": entry.family_hash,
+        "fingerprint": entry.fingerprint,
+        "tags": parse_tags(entry.tags),
+        "created_at": entry.created_at.isoformat(),
+        "is_error": entry.is_error,
+        "is_warning": entry.is_warning,
+        "payload_masked": True,
+    }
+
+    if not include_payload:
+        data["payload_omitted"] = True
+        return data
+
+    payload, truncated, original_size = _truncate_payload(entry.payload, max_payload_chars)
+    data.update(
+        {
+            "payload": payload,
+            "payload_truncated": truncated,
+            "payload_size_chars": original_size,
+        }
+    )
+    return data
+
+
+def _serialize_entries(entries: Iterable[OrbitEntry], *, limit: int | None = None) -> list[dict[str, Any]]:
+    safe_limit = _safe_limit(limit, DEFAULT_MAX_EVENTS)
+    return [agent_safe_serialize_entry(entry) for entry in list(entries)[:safe_limit]]
+
+
+def _event_counts(entries: Iterable[OrbitEntry]) -> dict[str, int]:
+    counts = Counter(entry.type for entry in entries)
+    return dict(sorted(counts.items()))
+
+
+def _diagnose(entries: list[OrbitEntry]) -> dict[str, Any]:
+    signals: list[str] = []
+    if any(entry.type == OrbitEntry.TYPE_EXCEPTION for entry in entries):
+        signals.append("exception")
+    if any(entry.type == OrbitEntry.TYPE_LOG and entry.is_error for entry in entries):
+        signals.append("error_log")
+    if any(entry.type == OrbitEntry.TYPE_QUERY and entry.payload.get("is_slow") for entry in entries):
+        signals.append("slow_query")
+    if any(entry.type == OrbitEntry.TYPE_QUERY and entry.payload.get("is_duplicate") for entry in entries):
+        signals.append("duplicate_query")
+    if any(entry.type == OrbitEntry.TYPE_REQUEST and entry.is_error for entry in entries):
+        signals.append("http_error")
+    if any(entry.type == OrbitEntry.TYPE_JOB and entry.is_error for entry in entries):
+        signals.append("job_error")
+
+    severity = "ok"
+    if "exception" in signals or "http_error" in signals or "job_error" in signals:
+        severity = "error"
+    elif "error_log" in signals or "slow_query" in signals or "duplicate_query" in signals:
+        severity = "warning"
+
+    hypotheses = []
+    if "exception" in signals:
+        hypotheses.append("An exception occurred in the request or related background flow.")
+    if "slow_query" in signals:
+        hypotheses.append("At least one SQL query exceeded the configured slow-query threshold.")
+    if "duplicate_query" in signals:
+        hypotheses.append("Duplicate SQL queries suggest a possible N+1 or missing eager loading pattern.")
+    if "error_log" in signals:
+        hypotheses.append("Error-level logs near the event may contain the domain-specific failure reason.")
+    if not hypotheses:
+        hypotheses.append("No strong failure signal was found in the captured Orbit entries.")
+
+    return {
+        "severity": severity,
+        "signals": signals,
+        "hypotheses": hypotheses,
+    }
+
+
+def _query_analysis(entries: list[OrbitEntry]) -> dict[str, Any]:
+    queries = [entry for entry in entries if entry.type == OrbitEntry.TYPE_QUERY]
+    slow = [entry for entry in queries if entry.payload.get("is_slow")]
+    duplicate = [entry for entry in queries if entry.payload.get("is_duplicate")]
+    top_slow = sorted(queries, key=lambda entry: entry.duration_ms or 0, reverse=True)[:5]
+    duplicate_signatures = Counter(
+        (entry.payload.get("sql") or "")[:180]
+        for entry in duplicate
+    )
+    return {
+        "total": len(queries),
+        "slow_count": len(slow),
+        "duplicate_count": len(duplicate),
+        "top_slow": _serialize_entries(top_slow, limit=5),
+        "duplicate_signatures": [
+            {"sql_preview": sql, "count": count}
+            for sql, count in duplicate_signatures.most_common(5)
+            if sql
+        ],
+    }
+
+
+def _timeline(entries: list[OrbitEntry]) -> list[dict[str, Any]]:
+    ordered = sorted(entries, key=lambda entry: entry.created_at)
+    first = ordered[0].created_at if ordered else None
+    result = []
+    for entry in ordered:
+        offset_ms = None
+        if first is not None:
+            offset_ms = round((entry.created_at - first).total_seconds() * 1000, 3)
+        item = agent_safe_serialize_entry(entry, include_payload=False)
+        item["offset_ms"] = offset_ms
+        result.append(item)
+    return result
+
+
+def _recommended_next_actions(diagnosis: dict[str, Any]) -> list[str]:
+    actions = ["Review the timeline and representative error context before editing code."]
+    signals = set(diagnosis.get("signals", []))
+    if "exception" in signals:
+        actions.append("Inspect the representative traceback and add a regression test for the failing path.")
+    if "duplicate_query" in signals:
+        actions.append("Check ORM relationships for select_related() or prefetch_related() opportunities.")
+    if "slow_query" in signals:
+        actions.append("Run EXPLAIN for the slowest SELECT query and review indexes/filter shape.")
+    if "error_log" in signals:
+        actions.append("Use nearby error logs to narrow the domain condition that triggered the failure.")
+    return actions
+
+
+def audit_mcp_exposure() -> dict[str, Any]:
+    """Return the effective agent-facing exposure policy."""
+    config = get_config()
+    return {
+        "mcp_enabled": bool(config.get("MCP_ENABLED", True)),
+        "include_payloads": bool(config.get("MCP_INCLUDE_PAYLOADS", True)),
+        "max_limit": _config_int("MCP_MAX_LIMIT", 100),
+        "max_payload_chars": _config_int("MCP_MAX_PAYLOAD_CHARS", DEFAULT_MAX_PAYLOAD_CHARS),
+        "high_level_tools": HIGH_LEVEL_TOOLS,
+        "safety": {
+            "serializer": "agent_safe_serialize_entry",
+            "payloads_masked": True,
+            "sensitive_keys": config.get("MASK_KEYS", []),
+            "truncation": "Payloads larger than MCP_MAX_PAYLOAD_CHARS are replaced with size metadata.",
+        },
+    }
+
+
+def investigate_request(family_hash: str, limit: int | None = None) -> dict[str, Any]:
+    """Build a bounded diagnosis for one request family."""
+    entries = list(OrbitEntry.objects.for_family(family_hash)[: _safe_limit(limit, DEFAULT_MAX_EVENTS)])
+    if not entries:
+        return {"error": f"No entries found for family_hash: {family_hash}"}
+
+    request = next((entry for entry in entries if entry.type == OrbitEntry.TYPE_REQUEST), entries[0])
+    diagnosis = _diagnose(entries)
+    return {
+        "family_hash": family_hash,
+        "request": agent_safe_serialize_entry(request),
+        "diagnosis": diagnosis,
+        "event_counts": _event_counts(entries),
+        "query_analysis": _query_analysis(entries),
+        "timeline": _timeline(entries),
+        "events": _serialize_entries(entries, limit=limit),
+        "recommended_next_actions": _recommended_next_actions(diagnosis),
+    }
+
+
+def _affected_paths_for_families(family_hashes: list[str]) -> list[dict[str, Any]]:
+    if not family_hashes:
+        return []
+    rows = (
+        OrbitEntry.objects.filter(type=OrbitEntry.TYPE_REQUEST, family_hash__in=family_hashes)
+        .values("payload__path")
+        .annotate(count=Count("id"))
+        .order_by("-count")[:10]
+    )
+    return [
+        {"path": row.get("payload__path") or "?", "count": row["count"]}
+        for row in rows
+    ]
+
+
+def investigate_exception_group(fingerprint: str, limit: int | None = None) -> dict[str, Any]:
+    """Summarize one exception fingerprint with blast-radius context."""
+    safe_limit = _safe_limit(limit, 50)
+    qs = OrbitEntry.objects.exceptions().filter(fingerprint=fingerprint).order_by("-created_at")
+    representative = qs.first()
+    if representative is None:
+        return {"error": f"No exception group found for fingerprint: {fingerprint}"}
+
+    exceptions = list(qs[:safe_limit])
+    family_hashes = [entry.family_hash for entry in exceptions if entry.family_hash]
+    related = list(OrbitEntry.objects.filter(family_hash__in=family_hashes).order_by("created_at")[:DEFAULT_MAX_EVENTS])
+    diagnosis = _diagnose(related or exceptions)
+    return {
+        "fingerprint": fingerprint,
+        "count": qs.count(),
+        "first_seen": qs.order_by("created_at").first().created_at.isoformat(),
+        "last_seen": representative.created_at.isoformat(),
+        "representative": agent_safe_serialize_entry(representative),
+        "affected_paths": _affected_paths_for_families(family_hashes),
+        "diagnosis": diagnosis,
+        "recent_occurrences": _serialize_entries(exceptions, limit=safe_limit),
+        "recommended_next_actions": _recommended_next_actions(diagnosis),
+    }
+
+
+
+def _resolve_source(source_type: str, source_value: str, hours: int = 72) -> dict[str, Any]:
+    if source_type == "family_hash":
+        return investigate_request(source_value)
+    if source_type == "fingerprint":
+        return investigate_exception_group(source_value)
+    if source_type in {"ticket", "query", "text"}:
+        return build_debug_brief(source_value, hours=hours)
+    return {"error": f"Unsupported source_type: {source_type}"}
+
+
+def _diagnosis_from_primary(primary: dict[str, Any]) -> dict[str, Any]:
+    diagnosis = primary.get("diagnosis")
+    if isinstance(diagnosis, dict):
+        return diagnosis
+    nested = primary.get("primary")
+    if isinstance(nested, dict) and isinstance(nested.get("diagnosis"), dict):
+        return nested["diagnosis"]
+    return {}
+
+
+def _collect_code_surfaces(value: Any) -> list[str]:
+    surfaces: list[str] = []
+
+    def _walk(item: Any) -> None:
+        if isinstance(item, dict):
+            filename = item.get("filename")
+            if filename and str(filename) not in surfaces:
+                surfaces.append(str(filename))
+            caller = item.get("caller")
+            if isinstance(caller, dict):
+                caller_filename = caller.get("filename")
+                if caller_filename and str(caller_filename) not in surfaces:
+                    surfaces.append(str(caller_filename))
+            for child in item.values():
+                _walk(child)
+        elif isinstance(item, list):
+            for child in item:
+                _walk(child)
+
+    _walk(value)
+    return surfaces[:10]
+
+
+def _bundle_to_markdown(bundle: dict[str, Any]) -> str:
+    primary = bundle.get("primary", {})
+    diagnosis = _diagnosis_from_primary(primary)
+    source = bundle.get("source", {})
+    lines = [
+        "# Django Orbit Incident Bundle",
+        "",
+        f"- Source: `{source.get('type')}` = `{source.get('value')}`",
+        f"- Generated: `{bundle.get('generated_at')}`",
+        f"- Severity: `{diagnosis.get('severity', 'unknown')}`",
+        "",
+        "## Signals",
+    ]
+    signals = diagnosis.get("signals") or []
+    if signals:
+        lines.extend(f"- `{signal}`" for signal in signals)
+    else:
+        lines.append("- No strong signal captured.")
+
+    lines.extend(["", "## Hypotheses"])
+    for hypothesis in diagnosis.get("hypotheses") or ["No hypothesis available."]:
+        lines.append(f"- {hypothesis}")
+
+    if primary.get("family_hash"):
+        request = primary.get("request") or {}
+        lines.extend([
+            "",
+            "## Request",
+            f"- Family hash: `{primary.get('family_hash')}`",
+            f"- Summary: {request.get('summary', '?')}",
+        ])
+    if primary.get("fingerprint"):
+        representative = primary.get("representative") or {}
+        lines.extend([
+            "",
+            "## Exception Group",
+            f"- Fingerprint: `{primary.get('fingerprint')}`",
+            f"- Count: `{primary.get('count')}`",
+            f"- Representative: {representative.get('summary', '?')}",
+        ])
+
+    events = primary.get("events") or primary.get("recent_occurrences") or []
+    if events:
+        lines.extend(["", "## Evidence"])
+        for event in events[:5]:
+            lines.append(f"- `{event.get('type')}` {event.get('summary', '?')}")
+
+
+    query_analysis = primary.get("query_analysis") or {}
+    if query_analysis:
+        lines.extend([
+            "",
+            "## Query Analysis",
+            f"- Total queries: `{query_analysis.get('total', 0)}`",
+            f"- Slow queries: `{query_analysis.get('slow_count', 0)}`",
+            f"- Duplicate queries: `{query_analysis.get('duplicate_count', 0)}`",
+        ])
+
+    lines.extend(["", "## Recommended Next Actions"])
+    for action in bundle.get("agent_handoff", {}).get("recommended_next_actions") or []:
+        lines.append(f"- {action}")
+
+    lines.extend([
+        "",
+        "## Safety",
+        "- Payloads are masked before export.",
+        "- Oversized payloads are replaced with truncation metadata.",
+    ])
+    return "\n".join(lines) + "\n"
+
+def create_incident_bundle(source_type: str, source_value: str, hours: int = 72, format: str = "json") -> dict[str, Any] | str:
+    """Create an on-demand agent handoff bundle without persisting state."""
+    primary = _resolve_source(source_type, source_value, hours=hours)
+    if "error" in primary:
+        return primary
+
+    diagnosis = _diagnosis_from_primary(primary)
+    bundle = {
+        "bundle_version": "agentic-v1",
+        "generated_at": timezone.now().isoformat(),
+        "source": {"type": source_type, "value": source_value},
+        "primary": primary,
+        "safety_report": {
+            "payloads_masked": True,
+            "payload_truncation_enabled": True,
+            "serializer": "agent_safe_serialize_entry",
+        },
+        "agent_handoff": {
+            "recommended_next_actions": _recommended_next_actions(diagnosis),
+            "suggested_tools": [
+                {"tool": "investigate_request", "when": "Use when a family_hash is identified."},
+                {"tool": "investigate_exception_group", "when": "Use when an exception fingerprint is identified."},
+                {"tool": "propose_fix_hypotheses", "when": "Use after the bundle identifies the dominant failure signal."},
+                {"tool": "propose_test_plan", "when": "Use before handing the issue to a coding agent."},
+            ],
+        },
+    }
+    if format == "markdown":
+        return _bundle_to_markdown(bundle)
+    if format != "json":
+        return {"error": f"Unsupported incident bundle format: {format}"}
+    return bundle
+
+
+def _search_terms(query: str) -> list[str]:
+    terms = []
+    for raw in query.replace("/", " ").replace("_", " ").split():
+        term = raw.strip().strip('"\'.,:;()[]{}').lower()
+        if len(term) >= 3 and term not in terms:
+            terms.append(term)
+    return terms[:8]
+
+
+def _build_search_q(terms: list[str]) -> Q:
+    condition = Q()
+    for term in terms:
+        condition |= Q(payload__icontains=term) | Q(tags__icontains=term)
+    return condition
+
+
+def build_debug_brief(query: str, hours: int = 72, limit: int | None = None) -> dict[str, Any]:
+    """Match ticket/error text to recent Orbit evidence and suggest next tools."""
+    safe_limit = _safe_limit(limit, 10)
+    terms = _search_terms(query)
+    since = timezone.now() - timezone.timedelta(hours=max(1, int(hours or 72)))
+    if not terms:
+        return {
+            "query": query,
+            "terms": [],
+            "matches": {"requests": [], "exceptions": [], "logs": []},
+            "suggested_tools": [],
+        }
+
+    condition = _build_search_q(terms)
+    base = OrbitEntry.objects.filter(created_at__gte=since).filter(condition).order_by("-created_at")
+    requests = list(base.filter(type=OrbitEntry.TYPE_REQUEST)[:safe_limit])
+    exceptions = list(base.filter(type=OrbitEntry.TYPE_EXCEPTION)[:safe_limit])
+    logs = list(base.filter(type=OrbitEntry.TYPE_LOG)[:safe_limit])
+
+    suggested = []
+    if exceptions:
+        fp = exceptions[0].fingerprint
+        if fp:
+            suggested.append({"tool": "create_incident_bundle", "source_type": "fingerprint", "source_value": fp})
+            suggested.append({"tool": "investigate_exception_group", "fingerprint": fp})
+    if requests:
+        family_hash = requests[0].family_hash
+        if family_hash:
+            suggested.append({"tool": "create_incident_bundle", "source_type": "family_hash", "source_value": family_hash})
+            suggested.append({"tool": "investigate_request", "family_hash": family_hash})
+
+    return {
+        "query": query,
+        "terms": terms,
+        "hours": hours,
+        "matches": {
+            "requests": _serialize_entries(requests, limit=safe_limit),
+            "exceptions": _serialize_entries(exceptions, limit=safe_limit),
+            "logs": _serialize_entries(logs, limit=safe_limit),
+        },
+        "suggested_tools": suggested,
+    }
+
+def propose_fix_hypotheses(source_type: str, source_value: str, hours: int = 72) -> dict[str, Any]:
+    """Rank likely fix directions from Orbit evidence without editing code."""
+    primary = _resolve_source(source_type, source_value, hours=hours)
+    if "error" in primary:
+        return primary
+
+    diagnosis = _diagnosis_from_primary(primary)
+    signals = set(diagnosis.get("signals", []))
+    hypotheses = []
+    if "exception" in signals:
+        hypotheses.append({
+            "title": "Fix the failing exception path",
+            "confidence": "high",
+            "evidence": "Orbit captured an exception in the matched request or exception group.",
+            "recommended_action": "Inspect the representative traceback and add a regression test before changing code.",
+        })
+    if "duplicate_query" in signals:
+        hypotheses.append({
+            "title": "Remove possible N+1 query pattern",
+            "confidence": "medium",
+            "evidence": "Duplicate SQL queries were captured in the request family.",
+            "recommended_action": "Review ORM relationship loading and consider select_related() or prefetch_related().",
+        })
+    if "slow_query" in signals:
+        hypotheses.append({
+            "title": "Optimize slow SQL path",
+            "confidence": "medium",
+            "evidence": "At least one query exceeded the slow-query threshold.",
+            "recommended_action": "Run EXPLAIN and check index/filter shape for the slowest SELECT.",
+        })
+    if "error_log" in signals:
+        hypotheses.append({
+            "title": "Use domain log message as failure clue",
+            "confidence": "medium",
+            "evidence": "Error-level logs were captured near the failure.",
+            "recommended_action": "Trace the log message to the application branch that emitted it.",
+        })
+    if not hypotheses:
+        hypotheses.append({
+            "title": "Collect more focused runtime evidence",
+            "confidence": "low",
+            "evidence": "Orbit did not capture a strong failure signal for this source.",
+            "recommended_action": "Reproduce the issue with request, query, log and exception recording enabled.",
+        })
+
+    return {
+        "source": {"type": source_type, "value": source_value},
+        "hypotheses": hypotheses,
+        "likely_code_surfaces": _collect_code_surfaces(primary),
+        "safety": {"does_not_modify_code": True, "uses_masked_payloads": True},
+    }
+
+
+def propose_test_plan(source_type: str, source_value: str, hours: int = 72) -> dict[str, Any]:
+    """Suggest tests that should cover the observed runtime failure."""
+    primary = _resolve_source(source_type, source_value, hours=hours)
+    if "error" in primary:
+        return primary
+
+    diagnosis = _diagnosis_from_primary(primary)
+    signals = set(diagnosis.get("signals", []))
+    request = primary.get("request") or {}
+    request_payload = request.get("payload") or {}
+    path = request_payload.get("path") or request_payload.get("full_path") or source_value
+    tests = [{
+        "type": "integration",
+        "target": str(path),
+        "purpose": "Reproduce the observed runtime path with Orbit evidence as the fixture for expected behavior.",
+    }]
+    if "exception" in signals:
+        tests.append({
+            "type": "unit",
+            "target": "exception branch",
+            "purpose": "Cover the failing branch from the representative traceback with a focused regression test.",
+        })
+    if "duplicate_query" in signals or "slow_query" in signals:
+        tests.append({
+            "type": "performance",
+            "target": str(path),
+            "purpose": "Assert query count or slow-query behavior does not regress after the fix.",
+        })
+    if "error_log" in signals:
+        tests.append({
+            "type": "integration",
+            "target": "logged failure condition",
+            "purpose": "Exercise the domain condition that emitted the error log.",
+        })
+
+    return {
+        "source": {"type": source_type, "value": source_value},
+        "recommended_tests": tests,
+        "safety": {"does_not_modify_code": True, "uses_masked_payloads": True},
+    }
+

--- a/orbit/conf.py
+++ b/orbit/conf.py
@@ -69,6 +69,9 @@ DEFAULTS = {
     "MAX_COMMAND_OUTPUT": 5000,
     # MCP server (v0.7.0+)
     "MCP_ENABLED": True,
+    "MCP_INCLUDE_PAYLOADS": True,
+    "MCP_MAX_LIMIT": 100,
+    "MCP_MAX_PAYLOAD_CHARS": 12000,
     # Storage backend (v0.8.0+)
     "STORAGE_BACKEND": "orbit.backends.database.DatabaseBackend",
     "STORAGE_DB_ALIAS": "orbit",  # only used by DjangoDBBackend

--- a/orbit/mcp_server.py
+++ b/orbit/mcp_server.py
@@ -23,23 +23,23 @@ logger = logging.getLogger(__name__)
 
 
 def _serialize_entry(entry) -> dict:
-    """Convert an OrbitEntry to a JSON-serializable dict."""
-    return {
-        "id": str(entry.id),
-        "type": entry.type,
-        "summary": entry.summary,
-        "duration_ms": entry.duration_ms,
-        "family_hash": entry.family_hash,
-        "created_at": entry.created_at.isoformat(),
-        "payload": entry.payload,
-        "is_error": entry.is_error,
-        "is_warning": entry.is_warning,
-    }
+    """Convert an OrbitEntry to an agent-safe JSON-serializable dict."""
+    from orbit.agentic import agent_safe_serialize_entry
+
+    return agent_safe_serialize_entry(entry)
 
 
 def _format_output(data: Any) -> str:
     """Format data as pretty-printed JSON string for AI consumption."""
     return json.dumps(data, indent=2, default=str)
+
+
+def _mcp_disabled_output() -> str:
+    """Return a stable response when MCP data exposure is disabled."""
+    return _format_output({
+        "error": "MCP data exposure is disabled by ORBIT_CONFIG['MCP_ENABLED'].",
+        "disabled": True,
+    })
 
 
 def create_mcp_server():
@@ -49,6 +49,10 @@ def create_mcp_server():
     Called lazily so Django ORM is available when tools run.
     """
     try:
+        import sys
+
+        if sys.modules.get("mcp") is None and "mcp" in sys.modules:
+            raise ImportError
         from mcp.server.fastmcp import FastMCP
     except ImportError:
         raise ImportError(
@@ -87,6 +91,9 @@ def create_mcp_server():
         Args:
             limit: Number of requests to return (max 100, default 20)
         """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+
         limit = min(limit, 100)
         entries = OrbitEntry.objects.requests().order_by("-created_at")[:limit]
         result = [_serialize_entry(e) for e in entries]
@@ -107,6 +114,9 @@ def create_mcp_server():
             threshold_ms: Minimum duration to consider slow (default: SLOW_QUERY_THRESHOLD_MS from config)
             limit: Number of results to return (max 100, default 20)
         """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+
         limit = min(limit, 100)
         threshold = threshold_ms if threshold_ms is not None else slow_threshold
 
@@ -137,6 +147,9 @@ def create_mcp_server():
             hours: How many hours back to look (default 24)
             limit: Number of results to return (max 100, default 20)
         """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+
         from django.utils import timezone
         from datetime import timedelta
 
@@ -166,6 +179,9 @@ def create_mcp_server():
         Args:
             limit: Number of results to return (max 50, default 20)
         """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+
         limit = min(limit, 50)
 
         # Requests where Orbit detected duplicate queries
@@ -207,6 +223,9 @@ def create_mcp_server():
                         gate, transaction, storage, job
             limit: Number of results to return (max 100, default 20)
         """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+
         limit = min(limit, 100)
 
         qs = OrbitEntry.objects.all()
@@ -243,6 +262,9 @@ def create_mcp_server():
         Args:
             family_hash: The family_hash value from any OrbitEntry
         """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+
         entries = OrbitEntry.objects.for_family(family_hash)
         if not entries.exists():
             return _format_output({"error": f"No entries found for family_hash: {family_hash}"})
@@ -276,6 +298,9 @@ def create_mcp_server():
         Args:
             hours: Time window in hours (default 24)
         """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+
         from django.utils import timezone
         from datetime import timedelta
         from django.db.models import Avg, Count
@@ -335,4 +360,94 @@ def create_mcp_server():
             "top_error_paths": list(top_errors),
         })
 
+
+    # -------------------------------------------------------------------------
+    # High-level agentic tools
+    # -------------------------------------------------------------------------
+    from orbit import agentic as agentic_tools
+
+    @mcp.tool(name="audit_mcp_exposure")
+    def audit_mcp_exposure_tool() -> str:
+        """
+        Report the effective MCP exposure and safety policy.
+
+        Use this before agentic investigations to understand whether payloads are
+        included, masked and size-limited.
+        """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+        return _format_output(agentic_tools.audit_mcp_exposure())
+
+    @mcp.tool()
+    def investigate_request(family_hash: str, limit: int = None) -> str:
+        """
+        Build a high-level diagnosis for one request family.
+
+        Returns the request summary, event counts, timeline, query analysis,
+        signals, hypotheses and recommended next actions.
+        """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+        return _format_output(agentic_tools.investigate_request(family_hash, limit=limit))
+
+    @mcp.tool()
+    def investigate_exception_group(fingerprint: str, limit: int = None) -> str:
+        """
+        Summarize one exception fingerprint with blast-radius context.
+
+        Returns representative error data, affected paths, recent occurrences,
+        hypotheses and next actions.
+        """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+        return _format_output(agentic_tools.investigate_exception_group(fingerprint, limit=limit))
+
+    @mcp.tool()
+    def create_incident_bundle(source_type: str, source_value: str, hours: int = 72, format: str = "json") -> str:
+        """
+        Create an on-demand agent handoff bundle.
+
+        source_type can be family_hash, fingerprint, ticket, query or text.
+        Bundles are generated from current OrbitEntry data and are not persisted.
+        """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+        result = agentic_tools.create_incident_bundle(source_type, source_value, hours=hours, format=format)
+        if isinstance(result, str):
+            return result
+        return _format_output(result)
+
+    @mcp.tool()
+    def build_debug_brief(query: str, hours: int = 72, limit: int = None) -> str:
+        """
+        Match ticket/error text to recent Orbit evidence.
+
+        Returns matched requests, exceptions and logs plus suggested next MCP
+        tools for deeper investigation.
+        """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+        return _format_output(agentic_tools.build_debug_brief(query, hours=hours, limit=limit))
+
+    @mcp.tool()
+    def propose_fix_hypotheses(source_type: str, source_value: str, hours: int = 72) -> str:
+        """
+        Rank likely fix directions from Orbit evidence without editing code.
+
+        source_type can be family_hash, fingerprint, ticket, query or text.
+        """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+        return _format_output(agentic_tools.propose_fix_hypotheses(source_type, source_value, hours=hours))
+
+    @mcp.tool()
+    def propose_test_plan(source_type: str, source_value: str, hours: int = 72) -> str:
+        """
+        Suggest tests that should cover the observed runtime failure.
+
+        source_type can be family_hash, fingerprint, ticket, query or text.
+        """
+        if not get_config().get("MCP_ENABLED", True):
+            return _mcp_disabled_output()
+        return _format_output(agentic_tools.propose_test_plan(source_type, source_value, hours=hours))
     return mcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "django-orbit"
 version = "0.10.0"
-description = "Satellite Observability for Django - A modern debugging and observability tool"
+description = "AI agent-native observability and debugging for Django"
 readme = "README.md"
 license = "MIT"
 authors = [
@@ -18,6 +18,9 @@ keywords = [
     "django",
     "debugging",
     "observability",
+    "ai",
+    "agents",
+    "mcp",
     "monitoring",
     "telescope",
     "profiling",
@@ -73,13 +76,15 @@ Changelog = "https://github.com/astro-stack/django-orbit/blob/main/CHANGELOG.md"
 "Bug Tracker" = "https://github.com/astro-stack/django-orbit/issues"
 
 [tool.setuptools]
-packages = ["orbit", "orbit.templatetags", "orbit.migrations", "orbit.backends"]
 include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["orbit*"]
+namespaces = true
 
 [tool.setuptools.package-data]
 orbit = [
     "templates/**/*.html",
-    "static/**/*",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-orbit"
-version = "0.9.1"
+version = "0.10.0"
 description = "Satellite Observability for Django - A modern debugging and observability tool"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -1,0 +1,212 @@
+import json
+
+import pytest
+from django.test import override_settings
+
+from orbit.models import OrbitEntry
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def request_entry(db):
+    return OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_REQUEST,
+        family_hash="fam-agentic",
+        duration_ms=320.0,
+        payload={
+            "method": "POST",
+            "path": "/checkout/",
+            "full_path": "/checkout/?debug=1",
+            "status_code": 500,
+            "headers": {"Authorization": "Bearer secret", "Accept": "application/json"},
+            "body": {"email": "user@example.com", "password": "secret"},
+            "query_count": 3,
+            "duplicate_query_count": 2,
+        },
+    )
+
+
+@pytest.fixture
+def related_entries(db, request_entry):
+    slow_query = OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_QUERY,
+        family_hash="fam-agentic",
+        duration_ms=900.0,
+        payload={
+            "sql": "SELECT * FROM orders WHERE user_id = %s",
+            "params": [123],
+            "duration_ms": 900.0,
+            "is_slow": True,
+            "is_duplicate": True,
+            "duplicate_count": 2,
+            "caller": {"filename": "/app/orders/views.py", "lineno": 42, "function": "checkout"},
+        },
+    )
+    log = OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_LOG,
+        family_hash="fam-agentic",
+        payload={"level": "ERROR", "message": "payment token rejected"},
+    )
+    exception = OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_EXCEPTION,
+        family_hash="fam-agentic",
+        fingerprint="fp-checkout",
+        payload={
+            "exception_type": "ValueError",
+            "message": "payment token rejected",
+            "traceback": [
+                {"filename": "/app/orders/views.py", "lineno": 45, "name": "checkout", "line": "raise ValueError()"}
+            ],
+            "traceback_string": "very long traceback",
+        },
+    )
+    return slow_query, log, exception
+
+
+def test_agent_safe_serialize_masks_and_truncates_payload(request_entry):
+    from orbit.agentic import agent_safe_serialize_entry
+
+    data = agent_safe_serialize_entry(request_entry, max_payload_chars=180)
+
+    assert data["id"] == str(request_entry.id)
+    assert data["summary"] == request_entry.summary
+    assert data["payload_truncated"] is True
+    encoded = json.dumps(data)
+    assert "secret" not in encoded
+    assert "***HIDDEN***" in encoded
+
+
+def test_agent_safe_serialize_can_omit_payload(request_entry):
+    from orbit.agentic import agent_safe_serialize_entry
+
+    data = agent_safe_serialize_entry(request_entry, include_payload=False)
+
+    assert "payload" not in data
+    assert data["payload_omitted"] is True
+
+
+def test_audit_mcp_exposure_reports_safety_config(settings):
+    from orbit.agentic import audit_mcp_exposure
+
+    settings.ORBIT_CONFIG = {
+        "MCP_ENABLED": True,
+        "MCP_INCLUDE_PAYLOADS": False,
+        "MCP_MAX_LIMIT": 25,
+    }
+
+    data = audit_mcp_exposure()
+
+    assert data["mcp_enabled"] is True
+    assert data["include_payloads"] is False
+    assert data["max_limit"] == 25
+    assert data["safety"]["serializer"] == "agent_safe_serialize_entry"
+
+
+def test_investigate_request_builds_diagnosis(request_entry, related_entries):
+    from orbit.agentic import investigate_request
+
+    data = investigate_request("fam-agentic")
+
+    assert data["family_hash"] == "fam-agentic"
+    assert data["request"]["id"] == str(request_entry.id)
+    assert data["diagnosis"]["severity"] == "error"
+    assert "exception" in data["diagnosis"]["signals"]
+    assert "slow_query" in data["diagnosis"]["signals"]
+    assert data["query_analysis"]["slow_count"] == 1
+    assert data["query_analysis"]["duplicate_count"] == 1
+    assert data["event_counts"] == {"request": 1, "query": 1, "log": 1, "exception": 1}
+
+
+def test_investigate_exception_group_summarizes_blast_radius(request_entry, related_entries):
+    from orbit.agentic import investigate_exception_group
+
+    data = investigate_exception_group("fp-checkout")
+
+    assert data["fingerprint"] == "fp-checkout"
+    assert data["count"] == 1
+    assert data["representative"]["type"] == "exception"
+    assert data["affected_paths"] == [{"path": "/checkout/", "count": 1}]
+    assert data["diagnosis"]["severity"] == "error"
+
+
+def test_create_incident_bundle_from_request(request_entry, related_entries):
+    from orbit.agentic import create_incident_bundle
+
+    data = create_incident_bundle("family_hash", "fam-agentic")
+
+    assert data["source"] == {"type": "family_hash", "value": "fam-agentic"}
+    assert data["primary"]["family_hash"] == "fam-agentic"
+    assert data["agent_handoff"]["recommended_next_actions"]
+    assert data["safety_report"]["payloads_masked"] is True
+
+def test_create_incident_bundle_markdown_from_request(request_entry, related_entries):
+    from orbit.agentic import create_incident_bundle
+
+    markdown = create_incident_bundle("family_hash", "fam-agentic", format="markdown")
+
+    assert isinstance(markdown, str)
+    assert "# Django Orbit Incident Bundle" in markdown
+    assert "fam-agentic" in markdown
+    assert "payment token rejected" in markdown
+    assert "secret" not in markdown
+
+
+def test_propose_fix_hypotheses_from_exception_group(request_entry, related_entries):
+    from orbit.agentic import propose_fix_hypotheses
+
+    data = propose_fix_hypotheses("fingerprint", "fp-checkout")
+
+    assert data["source"] == {"type": "fingerprint", "value": "fp-checkout"}
+    assert data["hypotheses"]
+    assert data["hypotheses"][0]["confidence"] in {"high", "medium", "low"}
+    assert any("orders/views.py" in item for item in data["likely_code_surfaces"])
+    assert data["safety"]["does_not_modify_code"] is True
+
+
+def test_propose_test_plan_from_request(request_entry, related_entries):
+    from orbit.agentic import propose_test_plan
+
+    data = propose_test_plan("family_hash", "fam-agentic")
+
+    assert data["source"] == {"type": "family_hash", "value": "fam-agentic"}
+    assert data["recommended_tests"]
+    assert any(test["type"] == "integration" for test in data["recommended_tests"])
+    assert any("checkout" in test["target"].lower() for test in data["recommended_tests"])
+    assert data["safety"]["does_not_modify_code"] is True
+def test_mcp_incident_bundle_markdown_returns_raw_text(request_entry, related_entries):
+    from orbit.mcp_server import create_mcp_server
+    from tests.test_mcp import _get_tool
+
+    fn = _get_tool(create_mcp_server(), "create_incident_bundle")
+    markdown = fn(source_type="family_hash", source_value="fam-agentic", format="markdown")
+
+    assert markdown.startswith("# Django Orbit Incident Bundle")
+    assert not markdown.startswith('"')
+
+def test_build_debug_brief_matches_ticket_text(request_entry, related_entries):
+    from orbit.agentic import build_debug_brief
+
+    data = build_debug_brief("checkout payment token rejected", hours=72)
+
+    assert data["query"] == "checkout payment token rejected"
+    assert data["matches"]["exceptions"][0]["id"] == str(related_entries[2].id)
+    assert data["matches"]["requests"][0]["id"] == str(request_entry.id)
+    assert data["suggested_tools"][0]["tool"] == "create_incident_bundle"
+
+
+@pytest.mark.django_db
+@override_settings(ORBIT_CONFIG={"MCP_ENABLED": True})
+def test_high_level_mcp_tools_are_registered():
+    from orbit.mcp_server import create_mcp_server
+    from tests.test_mcp import _call_tool
+
+    audit = _call_tool(create_mcp_server(), "audit_mcp_exposure")
+
+    assert audit["mcp_enabled"] is True
+    assert "investigate_request" in audit["high_level_tools"]
+    assert "propose_fix_hypotheses" in audit["high_level_tools"]
+    assert "propose_test_plan" in audit["high_level_tools"]
+
+
+

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -207,6 +207,3 @@ def test_high_level_mcp_tools_are_registered():
     assert "investigate_request" in audit["high_level_tools"]
     assert "propose_fix_hypotheses" in audit["high_level_tools"]
     assert "propose_test_plan" in audit["high_level_tools"]
-
-
-

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -128,6 +128,41 @@ def test_mcp_import_error_without_package(monkeypatch):
             sys.modules["mcp"] = original
 
 
+
+@pytest.mark.django_db
+@override_settings(ORBIT_CONFIG={"MCP_ENABLED": False})
+def test_mcp_enabled_false_blocks_all_tools(db):
+    OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_REQUEST,
+        family_hash="blocked",
+        payload={"method": "GET", "path": "/private/", "status_code": 200},
+    )
+    mcp = _make_server()
+    calls = [
+        ("get_recent_requests", {}),
+        ("get_slow_queries", {}),
+        ("get_exceptions", {}),
+        ("get_n1_patterns", {}),
+        ("search_entries", {"query": "private"}),
+        ("get_request_detail", {"family_hash": "blocked"}),
+        ("get_stats_summary", {}),
+        ("audit_mcp_exposure", {}),
+        ("investigate_request", {"family_hash": "blocked"}),
+        ("investigate_exception_group", {"fingerprint": "fp"}),
+        ("create_incident_bundle", {"source_type": "family_hash", "source_value": "blocked"}),
+        ("build_debug_brief", {"query": "private"}),
+        ("propose_fix_hypotheses", {"source_type": "family_hash", "source_value": "blocked"}),
+        ("propose_test_plan", {"source_type": "family_hash", "source_value": "blocked"}),
+    ]
+
+    for name, kwargs in calls:
+        data = _call_tool(mcp, name, **kwargs)
+        assert data == {
+            "error": "MCP data exposure is disabled by ORBIT_CONFIG['MCP_ENABLED'].",
+            "disabled": True,
+        }
+
+
 # ---------------------------------------------------------------------------
 # Tool: get_recent_requests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR positions Django Orbit v0.10.0 as an AI agent-native debugging layer for Django.

It adds:

- Agent-safe serialization for MCP responses, with sensitive-key masking and deterministic payload truncation metadata.
- High-level MCP investigation tools:
  - `audit_mcp_exposure`
  - `investigate_request`
  - `investigate_exception_group`
  - `create_incident_bundle`
  - `build_debug_brief`
  - `propose_fix_hypotheses`
  - `propose_test_plan`
- JSON and Markdown incident bundles for agent/human handoff.
- MCP config guards: `MCP_INCLUDE_PAYLOADS`, `MCP_MAX_LIMIT`, `MCP_MAX_PAYLOAD_CHARS`.
- v0.10.0 release docs, README positioning, roadmap and packaging cleanup.

Telemetry opt-in is intentionally not included in this release; it remains separated for a future version.

## Validation

- `python -m pytest --tb=short -q` -> `196 passed, 1 skipped`
- `python -m mkdocs build --strict` -> passed after cleaning generated `site/`
- `python -m build` -> built `django_orbit-0.10.0.tar.gz` and `django_orbit-0.10.0-py3-none-any.whl`
- `python -m twine check dist/*` -> passed
- Wheel contents verified:
  - `orbit/agentic.py`
  - `orbit/management/commands/orbit_mcp.py`
  - `orbit/management/commands/orbit_prune.py`
- `git diff --check` -> clean

## Notes

Local untracked `.codex/` and `AGENTS.md` files were intentionally left out of this PR.