### PR TITLE
fix(frontend): process HTMX after loading entry details

### DIFF
--- a/orbit/templates/orbit/dashboard.html
+++ b/orbit/templates/orbit/dashboard.html
@@ -523,6 +523,9 @@ function orbitDashboard() {
                 const response = await fetch(`${URLS.detail}${entryId}/`);
                 if (response.ok) {
                     container.innerHTML = await response.text();
+                    if (window.htmx) {
+                        htmx.process(container);
+                    }
                     lucide.createIcons();
                     
                     // Apply syntax highlighting to JSON


### PR DESCRIPTION
## Summary

This PR fixes the **Explain Plan** button in the Query Details panel.

### Problem

The Query Details panel is loaded dynamically using `fetch()` and rendered with:


container.innerHTML = await response.text();
3

The injected HTML contains HTMX attributes (`hx-get`, `hx-target`, etc.), but the dynamically inserted subtree was never processed by HTMX. As a result, the **Explain Plan** button was rendered but remained inactive.

### Root Cause

The dashboard already calls `htmx.process(container)` after dynamically refreshing the feed, but the same initialization step was missing when rendering the entry detail panel.

### Fix

Process the dynamically inserted detail panel with:

htmx.process(container);


after rendering the HTML so HTMX initializes the Explain Plan button and any other HTMX-enabled elements in the injected content.

### Testing

Tested locally with:

* Django 6.0.6
* PostgreSQL 18
* Orbit v0.10.0

Verified that:

* Query Details continue to render correctly.
* Explain Plan now issues the HTMX request.
* The Explain Plan response is rendered successfully.
* Existing dashboard functionality remains unaffected.
