### PR TITLE
feat(ui): add success indicator for explain plan

### DIFF
--- a/orbit/templates/orbit/dashboard.html
+++ b/orbit/templates/orbit/dashboard.html
@@ -377,6 +377,19 @@ function orbitDashboard() {
                 }
             });
 
+            // Show a success checkmark after the explain plan is loaded
+            document.body.addEventListener("htmx:afterSwap", (e) => {
+                if (!e.target.id.startsWith("explain-")) return;
+
+                const id = e.target.id.replace("explain-", "");
+
+                document
+                    .getElementById(`explain-success-${id}`)
+                    ?.classList.remove("hidden");
+
+                lucide.createIcons();
+            });
+
             // Keyboard shortcuts: Esc closes, j/k move between entries (Vim-style)
             document.addEventListener('keydown', (e) => {
                 if (e.key === 'Escape') {

--- a/orbit/templates/orbit/partials/detail.html
+++ b/orbit/templates/orbit/partials/detail.html
@@ -234,13 +234,26 @@
 
         <!-- EXPLAIN plan (B2), loaded on demand -->
         <div>
-            <button hx-get="{% url 'orbit:explain' entry.id %}"
-                    hx-target="#explain-{{ entry.id }}" hx-swap="innerHTML"
-                    hx-indicator="#explain-spin-{{ entry.id }}"
-                    class="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg bg-orbit-bg-tertiary/60 text-orbit-text-secondary hover:text-orbit-accent-cyan hover:bg-orbit-accent-cyan/10 transition-colors">
+            <button
+                hx-get="{% url 'orbit:explain' entry.id %}"
+                hx-target="#explain-{{ entry.id }}"
+                hx-swap="innerHTML"
+                hx-indicator="#explain-spin-{{ entry.id }}"
+                class="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg bg-orbit-bg-tertiary/60 text-orbit-text-secondary hover:text-orbit-accent-cyan hover:bg-orbit-accent-cyan/10 transition-colors">
+
                 <i data-lucide="search-code" class="w-4 h-4"></i>
-                <span>Explain plan</span>
-                <i id="explain-spin-{{ entry.id }}" data-lucide="loader-2" class="htmx-indicator w-4 h-4 animate-spin"></i>
+                <span>Explain Plan</span>
+
+                <!-- Spinner -->
+                <span id="explain-spin-{{ entry.id }}" class="htmx-indicator">
+                    <i data-lucide="loader-2" class="w-4 h-4 animate-spin"></i>
+                </span>
+
+                <!-- Success icon -->
+                <span id="explain-success-{{ entry.id }}" class="hidden">
+                    <i data-lucide="check" class="w-4 h-4 text-emerald-400"></i>
+                </span>
+
             </button>
             <div id="explain-{{ entry.id }}" class="mt-2"></div>
         </div>


### PR DESCRIPTION
## Summary

This PR improves the user experience of the **Explain Plan** action by providing visual feedback when the request completes successfully.

## Motivation

Currently, after an Explain Plan is loaded there is no indication that the operation has completed successfully.

This change displays a success indicator after the HTMX response has been swapped into the page, giving users immediate confirmation that the Explain Plan has finished loading.

## Changes

* Add a success icon to the Explain Plan button.
* Listen for the HTMX `afterSwap` event to detect when the Explain Plan content has been rendered.
* Display the success indicator once the Explain Plan has been successfully loaded.
* Keep the existing loading indicator during the request.

## Notes

This is a UI enhancement intended to improve user feedback for the Explain Plan workflow.

It builds upon the HTMX initialization fix introduced in the related Explain Plan bug fix.
