### PR TITLE
fix(explain): preserve JSONField adapter metadata during replay

### DIFF
--- a/orbit/adapters.py
+++ b/orbit/adapters.py
@@ -1,0 +1,250 @@
+"""
+orbit/adapters.py — Database adapter serialisation/replay for Orbit.
+
+Background
+----------
+Django's ORM adapts Python values into database-driver objects before they reach
+Orbit's query recorder.  A ``JSONField`` value, by the time the recorder's
+``execute`` wrapper fires, is no longer a plain ``dict`` — it is a driver-level
+wrapper such as psycopg3's ``Jsonb`` or psycopg2's ``Json``.  If Orbit stores a
+``str(Jsonb({...}))`` repr it can never replay the value faithfully; if it stores
+the raw ``dict`` the driver later raises "cannot adapt type 'dict'" during EXPLAIN.
+
+The solution implemented here has three stages:
+
+1. **Detect** — identify live adapter objects before they are serialised.
+2. **Unwrap** — extract the underlying Python value and store it with a generic
+   marker that names the adapter *kind* (e.g. ``"json"``).
+3. **Rebind** — at EXPLAIN replay time, reconstruct a driver-appropriate bindable
+   object for the target vendor from the stored marker.
+
+Why a named-kind marker rather than a boolean ``__orbit_json_value__``?
+-----------------------------------------------------------------------
+A boolean flag bakes in one adapter type for ever.  A string kind tag
+(``"__orbit_adapter__": "json"``) is open: adding ``"array"`` or ``"range"``
+support in future means writing one small detection/unwrap/rebind triplet and
+registering it — no changes to the shared dispatch logic or call sites.
+
+Backend-specific rebind notes
+------------------------------
+* **PostgreSQL** — wraps the value in ``psycopg.types.json.Jsonb`` (psycopg3) or
+  ``psycopg2.extras.Json``.  Falls back to a plain JSON string which Postgres
+  accepts for ``json``/``jsonb`` columns via an implicit cast.
+* **MySQL / SQLite** — both bind JSON columns from plain text.  Django's own
+  ``JSONField.get_prep_value()`` returns ``json.dumps(value, cls=self.encoder)``
+  (verified against Django source; neither backend overrides ``adapt_json_value``
+  with a wrapper object).  Plain ``json.dumps`` is therefore correct and
+  sufficient for both.
+
+Graceful degradation
+--------------------
+Every public function is safe to call with any value — including values from
+older Orbit entries, unknown adapter types, or environments where psycopg is not
+installed.  Failures are absorbed and callers receive a best-effort result or
+``None``/unchanged value, never an exception.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from typing import Any, Dict, Optional
+
+# ---------------------------------------------------------------------------
+# Public marker constant — single source of truth shared by recorders and
+# explain modules.  Import this; never hard-code the string elsewhere.
+# ---------------------------------------------------------------------------
+
+ADAPTER_MARKER_KEY = "__orbit_adapter__"
+
+
+# ---------------------------------------------------------------------------
+# Internal per-kind implementations
+# ---------------------------------------------------------------------------
+
+# --- json -------------------------------------------------------------------
+
+
+def _detect_json(value: Any) -> bool:
+    """Return True if *value* is a recognised psycopg JSON/JSONB adapter."""
+    module = getattr(type(value), "__module__", "") or ""
+    if not module.startswith("psycopg"):
+        return False
+    return type(value).__name__ in ("Json", "Jsonb")
+
+
+def _unwrap_json(value: Any) -> Optional[Dict[str, Any]]:
+    """
+    Extract the inner Python object from a psycopg Json/Jsonb wrapper.
+
+    psycopg does not document a stable public attribute for the wrapped object,
+    so we probe a short list of plausible names rather than hard-code one.  If
+    none resolves, return ``None`` so the caller can fall back to a safe repr.
+    """
+    for attr in ("obj", "adapted", "_obj", "wrapped"):
+        try:
+            inner = getattr(value, attr, _MISSING)
+        except Exception:
+            continue
+        if inner is _MISSING:
+            continue
+        # Only tag values that are themselves JSON-storable.  Anything else falls
+        # through to the generic str() path in the recorder's serialiser.
+        if inner is None or isinstance(inner, (dict, list, str, int, float, bool)):
+            return {ADAPTER_MARKER_KEY: "json", "value": inner}
+    return None
+
+
+def _rebind_json(marker: Dict[str, Any], vendor: str) -> Any:
+    """Reconstruct a bindable value from a ``"json"`` marker for *vendor*."""
+    inner = marker.get("value")
+
+    if vendor == "postgresql":
+        # Prefer psycopg3, fall back to psycopg2, then plain JSON text.
+        try:
+            from psycopg.types.json import Jsonb  # type: ignore[import]
+
+            return Jsonb(inner)
+        except Exception:
+            pass
+        try:
+            from psycopg2.extras import Json  # type: ignore[import]
+
+            return Json(inner)
+        except Exception:
+            pass
+
+    # MySQL, SQLite, and the Postgres fallback all accept plain JSON text.
+    # Django's JSONField.get_prep_value() uses json.dumps() for these backends.
+    return _json.dumps(inner)
+
+
+# ---------------------------------------------------------------------------
+# Kind registry — maps kind tag → (detect, unwrap, rebind)
+# ---------------------------------------------------------------------------
+# To add a new adapter type (e.g. "array", "range"):
+#   1. Write _detect_<kind>, _unwrap_<kind>, _rebind_<kind> functions above.
+#   2. Add one entry here.  Nothing else needs to change.
+
+_MISSING = object()  # sentinel for attribute probing
+
+_REGISTRY: Dict[str, tuple] = {
+    "json": (_detect_json, _unwrap_json, _rebind_json),
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def is_supported_adapter(value: Any) -> Optional[str]:
+    """
+    Return the adapter *kind* string (e.g. ``"json"``) if *value* is a
+    recognised database adapter object, otherwise return ``None``.
+
+    This is the single place where adapter detection logic lives.  Callers
+    should use this function rather than inspecting types directly.
+    """
+    for kind, (detect, _unwrap, _rebind) in _REGISTRY.items():
+        try:
+            if detect(value):
+                return kind
+        except Exception:
+            pass
+    return None
+
+
+def unwrap_adapter(value: Any) -> Any:
+    """
+    If *value* is a recognised database adapter object, return a
+    JSON-serialisable marker dict that encodes the adapter kind and the
+    underlying Python value::
+
+        {"__orbit_adapter__": "json", "value": {...}}
+
+    If *value* is not a recognised adapter, or if unwrapping fails for any
+    reason, return *value* unchanged so the recorder's generic serialiser can
+    handle it (falling back to ``str()`` if necessary).
+    """
+    kind = is_supported_adapter(value)
+    if kind is None:
+        return value
+
+    _detect, unwrap_fn, _rebind = _REGISTRY[kind]
+    try:
+        result = unwrap_fn(value)
+    except Exception:
+        result = None
+
+    # If the per-kind unwrap couldn't produce a marker, return the original so
+    # the caller's fallback (str repr) is used instead of silently losing data.
+    return result if result is not None else value
+
+
+def is_adapter_marker(value: Any) -> bool:
+    """Return True if *value* is an Orbit adapter marker dict."""
+    return isinstance(value, dict) and isinstance(value.get(ADAPTER_MARKER_KEY), str)
+
+
+def rebind_adapter(marker: Dict[str, Any], vendor: str) -> Any:
+    """
+    Given an Orbit adapter *marker* dict and a Django database *vendor* string
+    (``"postgresql"``, ``"mysql"``, ``"sqlite"``), return a value that the
+    corresponding driver can bind in a fresh ``cursor.execute()`` call.
+
+    If the marker kind is unknown or rebinding fails, returns the raw ``value``
+    field from the marker (a plain Python object) so the caller can decide how
+    to handle it.
+    """
+    kind = marker.get(ADAPTER_MARKER_KEY)
+    if kind not in _REGISTRY:
+        # Future-proof: unknown kind, return the wrapped value as-is.
+        return marker.get("value")
+
+    _detect, _unwrap, rebind_fn = _REGISTRY[kind]
+    try:
+        return rebind_fn(marker, vendor)
+    except Exception:
+        return marker.get("value")
+
+
+def rebind_params(params: Any, vendor: str) -> Any:
+    """
+    Walk *params* (a list or tuple) and rebind any Orbit adapter markers using
+    ``rebind_adapter``.  Non-marker values pass through unchanged.
+
+    Returns a new list; never mutates *params*.  Safe to call with ``None``.
+    """
+    if not isinstance(params, (list, tuple)):
+        return params
+    return [rebind_adapter(p, vendor) if is_adapter_marker(p) else p for p in params]
+
+
+def has_unbindable_param(params: Any) -> bool:
+    """
+    Return True if *params* contains a value that cannot be faithfully rebound
+    into a fresh ``cursor.execute()`` call, even after marker-tagged values have
+    been rebound by ``rebind_params``.
+
+    Unbindable shapes are legacy entries recorded before the adapter-unwrapping
+    fix was in place:
+
+    * A bare ``dict`` or ``list`` that is *not* an Orbit adapter marker — the
+      driver would raise "cannot adapt type 'dict'" when binding.
+    * A ``str`` that is a stringified adapter repr such as ``"Jsonb({...})"`` —
+      binding this raises "invalid input syntax for type json" against a JSON
+      column.
+
+    This check exists solely to produce a clear user-facing error instead of a
+    cryptic database exception.
+    """
+    if not isinstance(params, (list, tuple)):
+        return False
+    for p in params:
+        if is_adapter_marker(p):
+            continue  # handled by rebind_params
+        if isinstance(p, (dict, list)):
+            return True
+        if isinstance(p, str) and p.startswith(("Jsonb(", "Json(")):
+            return True
+    return False

--- a/orbit/explain.py
+++ b/orbit/explain.py
@@ -1,19 +1,45 @@
 """
-On-demand query EXPLAIN (B2).
+On-demand query EXPLAIN.
 
-Runs a query plan for a captured SQL statement, on demand only (never on the recording
-path). Vendor-aware (PostgreSQL / MySQL / SQLite) with graceful fallback. Plain ``EXPLAIN``
-does not execute the statement; ``EXPLAIN ANALYZE`` does, so it is gated behind config and
-only ever allowed for read-only ``SELECT`` statements, wrapped in a rolled-back savepoint.
+Runs a query plan for a captured SQL statement, on demand only (never on the
+recording path).  Vendor-aware (PostgreSQL / MySQL / SQLite) with graceful
+fallback.
+
+Plain ``EXPLAIN`` does not execute the statement; ``EXPLAIN ANALYZE`` does, so
+it is gated behind config and only ever allowed for read-only ``SELECT``
+statements, wrapped in a rolled-back savepoint.
+
+Parameter replay
+----------------
+When Orbit recorded the query, any database-adapter objects (e.g. psycopg
+``Jsonb``) were unwrapped by ``orbit.adapters.unwrap_adapter`` and stored as
+plain marker dicts.  At replay time, ``rebind_params`` reconstructs the correct
+driver-level object for the current backend so the planner receives properly
+typed values.
+
+For legacy entries recorded before this mechanism existed, stored parameters may
+be bare ``dict``/``list`` values or stringified reprs such as ``"Jsonb({...})"``.
+These cannot be safely rebound; ``has_unbindable_param`` detects them and the
+function returns a clear explanatory error rather than a cryptic database
+exception.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from django.db import connections, transaction
 
+from orbit.adapters import has_unbindable_param, rebind_params
+
 
 def _is_select(sql: str) -> bool:
-    return sql.lstrip().lower().startswith(("select", "with", "explain", "show", "pragma"))
+    return (
+        sql.lstrip().lower().startswith(("select", "with", "explain", "show", "pragma"))
+    )
+
+
+def _is_dml(sql: str) -> bool:
+    """True for INSERT/UPDATE/DELETE — statements plain EXPLAIN plans but does not execute."""
+    return sql.lstrip().lower().startswith(("insert", "update", "delete"))
 
 
 def _build_explain_sql(vendor: str, sql: str, analyze: bool) -> Optional[str]:
@@ -36,51 +62,93 @@ def explain_query(
     using: str = "default",
 ) -> Dict[str, Any]:
     """
-    Return {'supported', 'vendor', 'analyze', 'plan' (list[str]) | 'error'}.
+    Return a dict with keys: ``supported``, ``vendor``, ``analyze``, and either
+    ``plan`` (list of strings) or ``error`` (string).
 
-    Never raises: any failure is reported in 'error' so callers/UI can degrade gracefully.
+    Never raises: any failure is reported in ``error`` so callers and the UI can
+    degrade gracefully.
     """
-    result: Dict[str, Any] = {"supported": True, "analyze": False, "vendor": None}
+    result: Dict[str, Any] = {"supported": True,
+                              "analyze": False, "vendor": None}
 
     if not sql or not sql.strip():
         return {"supported": False, "error": "No SQL to explain"}
 
-    connection = connections[using]
-    vendor = connection.vendor
+    conn = connections[using]
+    vendor = conn.vendor
     result["vendor"] = vendor
 
-    # ANALYZE executes the statement — only ever for read-only SELECTs.
+    # ANALYZE executes the statement — restrict to read-only SELECTs.
     if analyze and not _is_select(sql):
         analyze = False
     result["analyze"] = analyze
 
+    # Rebuild driver-appropriate objects for any stored adapter markers.
+    # This must run before has_unbindable_param so that successfully rebound
+    # values are not falsely flagged as unbindable.
+    params = rebind_params(params, vendor)
+
+    # Plain EXPLAIN on DML still plans (and therefore binds) the statement.
+    # Detect legacy params that cannot be rebound and return a clear message
+    # instead of letting the database raise a cryptic type error.
+    if _is_dml(sql) and not analyze and has_unbindable_param(params):
+        return {
+            "supported": True,
+            "vendor": vendor,
+            "analyze": False,
+            "error": (
+                "Can't EXPLAIN this statement: it has a JSON-typed parameter that was "
+                "serialised for storage and can no longer be faithfully rebound. This "
+                "is a limitation of replaying captured parameters, not a database or "
+                "EXPLAIN support issue. Entries recorded after upgrading Orbit's "
+                "recorder should not hit this — only older captured entries can."
+            ),
+        }
+
     explain_sql = _build_explain_sql(vendor, sql, analyze)
     if explain_sql is None:
-        return {"supported": False, "vendor": vendor, "error": "EXPLAIN not supported for this database"}
+        return {
+            "supported": False,
+            "vendor": vendor,
+            "error": "EXPLAIN not supported for this database",
+        }
 
-    # Params may have been serialized for storage and not be re-bindable; fall back to
-    # running EXPLAIN without params (the plan rarely depends on literal values).
     def _run(bind_params):
-        with connection.cursor() as cursor:
+        with conn.cursor() as cursor:
             cursor.execute(explain_sql, bind_params)
             rows = cursor.fetchall()
         return ["  ".join(str(c) for c in row) for row in rows]
 
+    bound = params if isinstance(params, (list, tuple)) else None
+
     try:
         if analyze:
-            # Extra safety: execute inside a savepoint we always roll back.
+            # Execute inside a savepoint that is always rolled back.
             with transaction.atomic(using=using):
                 sid = transaction.savepoint(using=using)
                 try:
-                    plan = _run(params if isinstance(params, (list, tuple)) else None)
+                    plan = _run(bound)
                 finally:
                     transaction.savepoint_rollback(sid, using=using)
+        elif _is_dml(sql):
+            # Bindable (confirmed above); params are required for DML planning.
+            plan = _run(bound)
         else:
+            # For SELECT, fall back to no params if binding fails — the plan
+            # rarely depends on literal values, and a parameterless EXPLAIN is
+            # far more useful than an outright error.
             try:
-                plan = _run(params if isinstance(params, (list, tuple)) else None)
+                plan = _run(bound)
             except Exception:
                 plan = _run(None)
+
         result["plan"] = plan
         return result
-    except Exception as e:  # pragma: no cover - defensive
-        return {"supported": True, "vendor": vendor, "analyze": analyze, "error": str(e)}
+
+    except Exception as e:  # pragma: no cover — defensive
+        return {
+            "supported": True,
+            "vendor": vendor,
+            "analyze": analyze,
+            "error": str(e),
+        }

--- a/orbit/recorders.py
+++ b/orbit/recorders.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 
 from django.db import connection
 
+from orbit.adapters import unwrap_adapter
 from orbit.conf import get_config
 from orbit.watchers import cachalot_disabled
 
@@ -90,9 +91,12 @@ class OrbitQueryWrapper:
     Works with Django's connection.execute_wrapper() mechanism.
     """
 
-    def __init__(self, family_hash: Optional[str] = None, request_start: Optional[float] = None):
+    def __init__(
+        self, family_hash: Optional[str] = None, request_start: Optional[float] = None
+    ):
         self.family_hash = family_hash
-        self.request_start = request_start  # perf_counter() at request start (for waterfall)
+        # perf_counter() at request start (for waterfall)
+        self.request_start = request_start
         self.queries = []
         self.query_hashes = {}  # For duplicate detection
 
@@ -113,29 +117,23 @@ class OrbitQueryWrapper:
         config = get_config()
         slow_threshold = config.get("SLOW_QUERY_THRESHOLD_MS", 500)
 
-        # Record start time
         start_time = time.perf_counter()
 
         try:
             result = execute(sql, params, many, context)
             return result
         finally:
-            # Calculate duration
             duration_ms = (time.perf_counter() - start_time) * 1000
 
-            # Check for duplicates
             query_hash = _get_query_hash(sql)
             is_duplicate = query_hash in self.query_hashes
-            self.query_hashes[query_hash] = self.query_hashes.get(query_hash, 0) + 1
+            self.query_hashes[query_hash] = self.query_hashes.get(
+                query_hash, 0) + 1
             duplicate_count = self.query_hashes[query_hash]
 
-            # Check if slow
             is_slow = duration_ms > slow_threshold
-
-            # Get caller info
             caller = _extract_caller_info()
 
-            # Build query info
             query_info = {
                 "sql": sql,
                 "params": self._serialize_params(params),
@@ -147,23 +145,33 @@ class OrbitQueryWrapper:
                 "caller": caller,
             }
 
-            # Offset from request start, for the request waterfall (B4)
             if self.request_start is not None:
-                query_info["start_offset_ms"] = round((start_time - self.request_start) * 1000, 3)
+                query_info["start_offset_ms"] = round(
+                    (start_time - self.request_start) * 1000, 3
+                )
 
             self.queries.append(query_info)
-
-            # Also add to thread-local for access from middleware
             get_current_queries().append(query_info)
 
-    def _serialize_params(self, params) -> Any:
-        """Serialize query parameters for JSON storage."""
+    def _serialize_params(self, params: Any) -> Any:
+        """
+        Serialise query parameters for JSON storage.
+
+        Database backends adapt Python values into driver-level objects before
+        Orbit's wrapper fires (e.g. a JSONField dict becomes a psycopg ``Jsonb``
+        object).  ``unwrap_adapter`` detects these objects and replaces them with
+        a plain, JSON-serialisable marker dict so the value can be stored and
+        later replayed faithfully for on-demand EXPLAIN.  See ``orbit/adapters.py``
+        for the full explanation.
+        """
         from orbit.utils import serialize_for_json
 
         if params is None:
             return None
 
         try:
+            if isinstance(params, (list, tuple)):
+                params = [unwrap_adapter(p) for p in params]
             return serialize_for_json(params)
         except Exception:
             return str(params)

--- a/tests/test_adapter_explain.py
+++ b/tests/test_adapter_explain.py
@@ -1,0 +1,406 @@
+"""
+Tests for orbit.adapters, orbit.recorders (param serialisation), and
+orbit.explain — covering the JSON adapter unwrap/rebind pipeline and
+its graceful-degradation guarantees.
+
+Run with:  pytest tests/test_adapter_explain.py -v
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from orbit.adapters import (
+    ADAPTER_MARKER_KEY,
+    has_unbindable_param,
+    is_adapter_marker,
+    is_supported_adapter,
+    rebind_adapter,
+    rebind_params,
+    unwrap_adapter,
+)
+
+pytestmark = pytest.mark.django_db
+
+# ---------------------------------------------------------------------------
+# Helpers / fakes
+# ---------------------------------------------------------------------------
+
+
+class Jsonb:
+    """Minimal psycopg3-style Jsonb stand-in."""
+
+    __module__ = "psycopg"
+
+    def __init__(self, obj):
+        self.obj = obj
+
+
+class Json:
+    """Minimal psycopg2-style Json stand-in."""
+
+    __module__ = "psycopg2"
+
+    def __init__(self, obj):
+        self.obj = obj
+
+
+class _UnknownAdapter:
+    """Something the registry knows nothing about."""
+
+    __module__ = "some_other_driver"
+
+    def __init__(self, val):
+        self.val = val
+
+
+def _json_marker(value):
+    return {ADAPTER_MARKER_KEY: "json", "value": value}
+
+
+# ---------------------------------------------------------------------------
+# orbit.adapters — detection
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+class TestIsSupported:
+    def test_psycopg3_jsonb(self):
+        assert is_supported_adapter(Jsonb({"k": 1})) == "json"
+
+    def test_psycopg2_json(self):
+        assert is_supported_adapter(Json([1, 2])) == "json"
+
+    def test_plain_dict_not_adapter(self):
+        assert is_supported_adapter({"k": 1}) is None
+
+    def test_plain_str_not_adapter(self):
+        assert is_supported_adapter("hello") is None
+
+    def test_none_not_adapter(self):
+        assert is_supported_adapter(None) is None
+
+    def test_unknown_adapter_class_not_adapter(self):
+        assert is_supported_adapter(_UnknownAdapter(42)) is None
+
+
+# ---------------------------------------------------------------------------
+# orbit.adapters — unwrapping
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+class TestUnwrapAdapter:
+    def test_jsonb_dict(self):
+        marker = unwrap_adapter(Jsonb({"level": "INFO"}))
+        assert marker == _json_marker({"level": "INFO"})
+
+    def test_json_list(self):
+        marker = unwrap_adapter(Json([1, 2, 3]))
+        assert marker == _json_marker([1, 2, 3])
+
+    def test_plain_value_passthrough(self):
+        val = {"plain": "dict"}
+        assert unwrap_adapter(val) is val
+
+    def test_none_passthrough(self):
+        assert unwrap_adapter(None) is None
+
+    def test_integer_passthrough(self):
+        assert unwrap_adapter(42) == 42
+
+    def test_unknown_adapter_passthrough(self):
+        obj = _UnknownAdapter(99)
+        assert unwrap_adapter(obj) is obj
+
+    def test_unwrap_preserves_null_inner_value(self):
+        """None is a valid JSON value — it must survive the round-trip."""
+        marker = unwrap_adapter(Jsonb(None))
+        assert marker == _json_marker(None)
+
+    def test_unwrap_exception_returns_original(self):
+        """If the unwrap function itself raises, the original value is returned."""
+        bad = Jsonb({"x": 1})
+        # Sabotage the attribute lookup
+        del bad.obj
+        result = unwrap_adapter(bad)
+        # Should get the original object back, not raise
+        assert result is bad
+
+
+# ---------------------------------------------------------------------------
+# orbit.adapters — marker identification
+# ---------------------------------------------------------------------------
+
+
+class TestIsAdapterMarker:
+    def test_valid_json_marker(self):
+        assert is_adapter_marker(_json_marker({"a": 1})) is True
+
+    def test_dict_without_key_is_not_marker(self):
+        assert is_adapter_marker({"value": 1}) is False
+
+    def test_marker_key_must_be_string(self):
+        assert is_adapter_marker(
+            {ADAPTER_MARKER_KEY: True, "value": 1}) is False
+
+    def test_non_dict_is_not_marker(self):
+        assert is_adapter_marker("hello") is False
+        assert is_adapter_marker(None) is False
+        assert is_adapter_marker(42) is False
+
+
+# ---------------------------------------------------------------------------
+# orbit.adapters — rebinding
+# ---------------------------------------------------------------------------
+
+
+class TestRebindAdapter:
+    def test_sqlite_returns_json_text(self):
+        marker = _json_marker({"k": "v"})
+        result = rebind_adapter(marker, "sqlite")
+        assert result == json.dumps({"k": "v"})
+
+    def test_mysql_returns_json_text(self):
+        marker = _json_marker([1, 2])
+        result = rebind_adapter(marker, "mysql")
+        assert result == json.dumps([1, 2])
+
+    def test_postgresql_falls_back_to_json_text_without_psycopg(self):
+        """
+        When psycopg is not importable, the Postgres rebind path must fall back
+        to plain JSON text rather than raising.
+        """
+        marker = _json_marker({"x": 1})
+        with patch("builtins.__import__", side_effect=ImportError):
+            result = rebind_adapter(marker, "postgresql")
+        assert result == json.dumps({"x": 1})
+
+    def test_unknown_kind_returns_value(self):
+        marker = {ADAPTER_MARKER_KEY: "array", "value": [1, 2, 3]}
+        result = rebind_adapter(marker, "postgresql")
+        assert result == [1, 2, 3]
+
+    def test_null_json_value_round_trips(self):
+        marker = _json_marker(None)
+        result = rebind_adapter(marker, "sqlite")
+        assert result == "null"
+
+
+class TestRebindParams:
+    def test_mixed_params(self):
+        params = [42, _json_marker({"a": 1}), "plain"]
+        result = rebind_params(params, "sqlite")
+        assert result[0] == 42
+        assert result[1] == json.dumps({"a": 1})
+        assert result[2] == "plain"
+
+    def test_none_params_passthrough(self):
+        assert rebind_params(None, "sqlite") is None
+
+    def test_empty_list(self):
+        assert rebind_params([], "sqlite") == []
+
+    def test_returns_new_list_not_original(self):
+        params = [1, 2]
+        result = rebind_params(params, "sqlite")
+        assert result is not params
+
+
+# ---------------------------------------------------------------------------
+# orbit.adapters — unbindable-param detection
+# ---------------------------------------------------------------------------
+
+
+class TestHasUnbindableParam:
+    def test_clean_params_are_bindable(self):
+        assert has_unbindable_param([1, "hello", None]) is False
+
+    def test_bare_dict_is_unbindable(self):
+        assert has_unbindable_param([{"key": "value"}]) is True
+
+    def test_bare_list_is_unbindable(self):
+        assert has_unbindable_param([[1, 2, 3]]) is True
+
+    def test_stringified_jsonb_repr_is_unbindable(self):
+        assert has_unbindable_param(["Jsonb({'level': 'INFO'})"]) is True
+
+    def test_stringified_json_repr_is_unbindable(self):
+        assert has_unbindable_param(["Json({'k': 'v'})"]) is True
+
+    def test_marker_dict_is_not_unbindable(self):
+        # Markers are handled by rebind_params before this check runs.
+        assert has_unbindable_param([_json_marker({"k": 1})]) is False
+
+    def test_none_params(self):
+        assert has_unbindable_param(None) is False
+
+    def test_non_list_params(self):
+        assert has_unbindable_param("raw_string") is False
+
+
+# ---------------------------------------------------------------------------
+# orbit.explain — integration (SQL classification + EXPLAIN dispatch)
+# ---------------------------------------------------------------------------
+
+# We test explain_query by patching the database cursor rather than touching
+# a real database, so the tests remain backend-agnostic and fast.
+
+
+def _mock_connection(vendor="postgresql", plan_rows=None):
+    """Return a mock Django connection object."""
+    if plan_rows is None:
+        plan_rows = [("Seq Scan on users  (cost=0.00..35.50 rows=2550)",)]
+
+    cursor = MagicMock()
+    cursor.__enter__ = lambda s: s
+    cursor.__exit__ = MagicMock(return_value=False)
+    cursor.fetchall.return_value = plan_rows
+
+    conn = MagicMock()
+    conn.vendor = vendor
+    conn.cursor.return_value = cursor
+    return conn, cursor
+
+
+@pytest.mark.django_db
+class TestExplainQuery:
+    """Tests for orbit.explain.explain_query."""
+
+    def _run(
+        self, sql, params=None, analyze=False, vendor="postgresql", plan_rows=None
+    ):
+        from orbit.explain import explain_query
+
+        conn, cursor = _mock_connection(vendor=vendor, plan_rows=plan_rows)
+        with patch("orbit.explain.connections", {vendor: conn}):
+            return explain_query(sql, params=params, analyze=analyze, using=vendor)
+
+    # --- basic SELECT -------------------------------------------------------
+
+    def test_select_explain_returns_plan(self):
+        result = self._run("SELECT 1", vendor="postgresql")
+        assert result["supported"] is True
+        assert "plan" in result
+        assert "error" not in result
+
+    def test_select_explain_sqlite(self):
+        result = self._run(
+            "SELECT * FROM auth_user",
+            vendor="sqlite",
+            plan_rows=[("0", "0", "0", "SCAN auth_user")],
+        )
+        assert result["supported"] is True
+        assert "plan" in result
+
+    def test_select_explain_mysql(self):
+        result = self._run(
+            "SELECT * FROM auth_user",
+            vendor="mysql",
+            plan_rows=[("1", "SIMPLE", "auth_user", None, "ALL")],
+        )
+        assert result["supported"] is True
+        assert "plan" in result
+
+    def test_empty_sql_unsupported(self):
+        from orbit.explain import explain_query
+
+        result = explain_query("", using="default")
+        assert result["supported"] is False
+        assert "error" in result
+
+    # --- INSERT without JSONField -------------------------------------------
+
+    def test_insert_without_json_param_returns_plan(self):
+        sql = "INSERT INTO logs (level, message) VALUES (%s, %s)"
+        result = self._run(sql, params=["INFO", "hello"], vendor="postgresql")
+        assert result["supported"] is True
+        assert "plan" in result
+
+    # --- INSERT with JSONField (new marker format) --------------------------
+
+    def test_insert_with_json_marker_param_returns_plan(self):
+        """
+        A JSONField parameter stored with the new marker format is rebound
+        by rebind_params before EXPLAIN runs.
+        """
+        sql = "INSERT INTO events (payload) VALUES (%s)"
+        marker_param = _json_marker({"event": "login", "user_id": 42})
+        # After rebind_params, the marker becomes a JSON text string (sqlite path
+        # used here to avoid psycopg import requirement in CI).
+        result = self._run(sql, params=[marker_param], vendor="sqlite")
+        assert result["supported"] is True
+        assert "plan" in result
+
+    # --- UPDATE with JSONField (new marker format) --------------------------
+
+    def test_update_with_json_marker_param_returns_plan(self):
+        sql = "UPDATE events SET payload = %s WHERE id = %s"
+        params = [_json_marker({"k": "v"}), 1]
+        result = self._run(sql, params=params, vendor="sqlite")
+        assert result["supported"] is True
+        assert "plan" in result
+
+    # --- Legacy payload — unbindable params --------------------------------
+
+    def test_insert_with_legacy_bare_dict_param_returns_error(self):
+        """
+        An INSERT recorded before the adapter-unwrapping fix stores params as
+        bare dicts, which cannot be rebound.  Expect a clear error message.
+        """
+        sql = "INSERT INTO events (payload) VALUES (%s)"
+        result = self._run(
+            sql, params=[{"level": "INFO"}], vendor="postgresql")
+        assert result["supported"] is True
+        assert "plan" not in result
+        assert "error" in result
+        assert "JSON-typed parameter" in result["error"]
+
+    def test_insert_with_stringified_jsonb_repr_returns_error(self):
+        sql = "INSERT INTO events (payload) VALUES (%s)"
+        result = self._run(
+            sql, params=["Jsonb({'level': 'INFO'})"], vendor="postgresql"
+        )
+        assert "error" in result
+        assert "plan" not in result
+
+    # --- Unknown adapter degrades gracefully --------------------------------
+
+    def test_unknown_adapter_object_in_select_does_not_raise(self):
+        """
+        An unrecognised adapter object in a SELECT falls through gracefully —
+        SELECT has a no-params fallback so the plan still executes.
+        """
+        sql = "SELECT * FROM logs WHERE id = %s"
+        obj = _UnknownAdapter(42)
+        # unwrap_adapter returns the object unchanged; rebind_params passes it
+        # through; the SELECT fallback path retries without params.
+        result = self._run(sql, params=[obj], vendor="postgresql")
+        # Should not raise and should have a plan (via the fallback path)
+        assert "error" not in result or result.get("plan") is not None
+
+    # --- ANALYZE gating ----------------------------------------------------
+
+    def test_analyze_on_insert_is_silently_downgraded(self):
+        """ANALYZE is only safe for SELECTs; non-SELECTs must drop the flag."""
+        sql = "INSERT INTO logs (msg) VALUES (%s)"
+        result = self._run(sql, params=["hi"], vendor="postgresql")
+        assert result.get("analyze") is False
+
+    def test_analyze_true_on_select(self):
+        sql = "SELECT 1"
+        from orbit.explain import explain_query
+
+        conn, cursor = _mock_connection(vendor="postgresql")
+        # Patch transaction primitives so the savepoint dance doesn't fail
+        with (
+            patch("orbit.explain.connections", {"postgresql": conn}),
+            patch("orbit.explain.transaction") as mock_tx,
+        ):
+            mock_tx.atomic.return_value.__enter__ = lambda s: s
+            mock_tx.atomic.return_value.__exit__ = MagicMock(
+                return_value=False)
+            mock_tx.savepoint.return_value = "sp1"
+            mock_tx.savepoint_rollback = MagicMock()
+            result = explain_query(sql, analyze=True, using="postgresql")
+
+        assert result.get("analyze") is True


### PR DESCRIPTION
## Summary

Fixes EXPLAIN replay for SQL statements containing `JSONField` parameters.

Django adapts `JSONField` values into backend-specific database adapter objects (for example, psycopg's `Json`/`Jsonb`) before `connection.execute_wrapper()` is invoked. Orbit previously serialized these adapter objects using their string representation, which prevented parameterized write queries from being replayed correctly during EXPLAIN.

This change introduces a small adapter serialization layer that:

* Detects supported database adapter objects during query recording.
* Stores adapter metadata in a backend-agnostic format.
* Reconstructs bindable parameters during EXPLAIN replay.
* Gracefully handles legacy recorded entries that cannot be faithfully replayed.

The adapter implementation is registry-based, making it straightforward to support additional adapter types in the future without changing the replay pipeline.

## Tests

Added regression tests covering:

* SELECT EXPLAIN
* INSERT without JSONField parameters
* INSERT with JSONField parameters
* UPDATE with JSONField parameters
* Legacy payload handling
* Graceful degradation for unknown adapter objects

All existing tests continue to pass.


243 passed, 1 skipped
