### PR TITLE
ci: add PyPI trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish package
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install build backend
+        run: python -m pip install --upgrade build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow for PyPI trusted publishing via OIDC
- Support both published GitHub releases and manual workflow dispatch
- Use the protected \pypi\ environment before publishing

## Test plan
- Inspected the generated workflow diff
- Workflow will be validated by GitHub Actions after PR creation

## Release note
After this lands on \main\, configure PyPI trusted publishing with owner \stro-stack\, repository \django-orbit\, workflow \publish.yml\, environment \pypi\. Then run the workflow manually to publish \