### PR TITLE
docs: introduce Orbit Pro founder waitlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Unlike Django Debug Toolbar, Orbit does not inject HTML into your app. It lives 
 - [Documentation](https://astro-stack.github.io/django-orbit)
 - [Try the demo](#try-the-demo)
 - [MCP / AI assistant setup](#mcp-ai-assistant-setup)
+- [Orbit Pro founder waitlist](https://labs.wearehik.com/django-orbit/pro/)
 
 ## Why Orbit
 
@@ -40,6 +41,18 @@ Django teams increasingly debug with AI coding agents, but most local observabil
 | Plug-and-play watcher health | No | Yes |
 
 Inspired by Laravel Telescope, Spatie Ray and Django Debug Toolbar.
+
+## Orbit Pro
+
+Django Orbit remains MIT-licensed and fully useful on its own: the local dashboard,
+watchers, MCP tools, masking, incident bundles and safety controls stay in the open
+source package.
+
+[Orbit Pro](https://labs.wearehik.com/django-orbit/pro/) is the planned self-hosted
+verification layer for teams using coding agents. It will build on the open core
+with release comparison, saved investigations and verification of agent-assisted
+changes against new runtime evidence. Join the founder waitlist to help define the
+first paid release.
 
 ## What Orbit Tracks
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,11 @@ Welcome to the Django Orbit documentation. This guide covers installation, confi
 
 Django Orbit is an AI agent-native observability and debugging tool for Django applications. Unlike Django Debug Toolbar, which injects HTML into your templates, Orbit runs on its own isolated URL and exposes structured runtime evidence through both a human dashboard and MCP tools for AI assistants.
 
+!!! info "Orbit Pro founder waitlist"
+    Django Orbit remains MIT-licensed. [Orbit Pro](https://labs.wearehik.com/django-orbit/pro/)
+    is the planned self-hosted verification layer for release comparison, saved
+    investigations and evidence-backed validation of agent-assisted changes.
+
 ### Key Concepts
 
 - **OrbitEntry**: The central model that stores all telemetry data

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,9 @@ nav:
     - Publishing: publishing.md
     - Security: security.md
     - Troubleshooting: troubleshooting.md
+  - Product:
+    - Django Orbit Site: https://labs.wearehik.com/django-orbit/
+    - Orbit Pro: https://labs.wearehik.com/django-orbit/pro/
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
## Summary
- document the open-source and Orbit Pro boundary in the README
- add the founder waitlist to the documentation home
- add product links to MkDocs navigation

## Verification
- `python -m mkdocs build --strict`