### PR TITLE
feat: add agent-safe Evidence API v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the public `orbit.evidence.v1` API for deterministic, metadata-first,
+  fail-silent reads of normalized request-family evidence, including explicit
+  completeness signals, structured recovery actions, bounded identifiers, and
+  query-string-free endpoint paths.
 - Added an authenticated Configuration Center that reports the effective
   settings source, exposes project identity and capture/safety controls, and
   generates a validated `ORBIT_CONFIG` preview without mutating runtime state.

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,26 @@ Orbit ships a dashboard UI plus a small set of internal routes used by that inte
 !!! note
     Orbit does not currently expose a public REST API for entries. The routes above are the dashboard and its internal UI endpoints.
 
+## Evidence API
+
+For integrations, use the public metadata-first Evidence API instead of
+depending on model payload internals:
+
+```python
+from orbit.evidence import read_family_evidence
+
+evidence = read_family_evidence("request-family-hash", limit=250)
+```
+
+The response uses the versioned `orbit.evidence.v1` schema and contains
+normalized plain dictionaries. Storage failures return a structured
+`unavailable` state instead of raising into the host application. Callers must
+check both `status` and `evidence_quality.status`. Raw payloads, summaries, SQL,
+headers, bodies, messages, and tracebacks are not included.
+
+See the [Evidence API guide](evidence-api.md) for the schema, safety boundary,
+limits, and compatibility policy.
+
 ## Models
 
 ### OrbitEntry
@@ -53,5 +73,6 @@ family_entries = OrbitEntry.objects.filter(family_hash="...")
 ## Related References
 
 - [Dashboard Guide](dashboard.md)
+- [Evidence API](evidence-api.md)
 - [Stats Dashboard](stats.md)
 - [MCP Server](mcp.md)

--- a/docs/evidence-api.md
+++ b/docs/evidence-api.md
@@ -1,0 +1,250 @@
+# Evidence API
+
+Orbit provides a public, versioned read boundary for integrations that need
+runtime evidence without depending on `OrbitEntry` internals:
+
+```python
+from orbit.evidence import read_family_evidence
+
+evidence = read_family_evidence("request-family-hash")
+```
+
+The current schema identifier is `orbit.evidence.v1`.
+
+## Why Use It
+
+Direct ORM access exposes Orbit's complete payload schema and couples an
+integration to internal model details. The Evidence API returns plain Python
+dictionaries with a small, documented set of normalized fields.
+
+Use it for local debugging extensions, CI helpers, incident tooling, or
+agent-assisted workflows that need a stable, metadata-first input.
+
+## Find a Family Hash
+
+The MCP `get_recent_requests` tool returns the complete `family_hash`. A
+local integration can also select a captured request from `python manage.py shell`
+and pass its hash to the Evidence API:
+
+```python
+from orbit.evidence import read_family_evidence
+from orbit.models import OrbitEntry
+
+request = (
+    OrbitEntry.objects.requests()
+    .exclude(family_hash=None)
+    .latest("created_at")
+)
+evidence = read_family_evidence(request.family_hash)
+```
+
+Use the full hash. A shortened value copied from a dashboard label may not
+identify the family.
+
+## Family Response
+
+```json
+{
+  "schema_version": "orbit.evidence.v1",
+  "status": "ok",
+  "reason": null,
+  "family_hash": "abc123",
+  "count": 1,
+  "truncated": false,
+  "evidence_quality": {
+    "status": "complete",
+    "warnings": [],
+    "missing_fields": [],
+    "truncated_fields": [],
+    "unsupported_entry_types": [],
+    "next_actions": []
+  },
+  "entries": [
+    {
+      "id": "7fb37d9d-815b-43d5-8e5f-3faed295ef98",
+      "type": "request",
+      "family_hash": "abc123",
+      "fingerprint": null,
+      "created_at": "2026-07-23T12:00:00+00:00",
+      "duration_ms": 123.4,
+      "attributes": {
+        "method": "GET",
+        "path": "/checkout/",
+        "status_code": 200,
+        "query_count": 4,
+        "duplicate_query_count": 0,
+        "had_exception": false
+      },
+      "truncated_fields": []
+    }
+  ]
+}
+```
+
+`status` reports whether the read operation succeeded. It does not say that
+Orbit captured every event needed for a conclusion.
+
+| Status | Reason | Meaning | Recommended response |
+|--------|--------|---------|----------------------|
+| `ok` | `null` | One or more normalized entries were read | Check `evidence_quality.status` before evaluating the result |
+| `not_found` | `family_not_found` | No matching entries are currently stored | Verify the full hash, capture settings, pruning, and retention |
+| `invalid` | `invalid_family_hash` | The hash is blank, padded, malformed, or too long | Supply a valid full family hash |
+| `invalid` | `invalid_limit` | The limit is outside `1..5000` | Retry with a valid limit |
+| `unavailable` | `storage_unavailable` | The Orbit table is not available | Verify migrations and the configured storage alias |
+| `unavailable` | `read_failed` | Storage could not be read safely | Retry and inspect server logs |
+
+Database exception text and storage details are never returned. A `not_found`
+response is not proof that an event did not happen.
+
+## Evidence Quality
+
+`evidence_quality.status` is the completeness signal for automated consumers:
+
+| Quality | Meaning |
+|---------|---------|
+| `complete` | All normalized v1 fields for supported entry types are present and the family did not exceed the requested limit |
+| `partial` | The family was clipped, a field is missing or shortened, or the family contains an entry type not normalized by v1 |
+| `unavailable` | The read could not provide evidence to evaluate |
+
+The object includes machine-readable `warnings`, `missing_fields`,
+`truncated_fields`, `unsupported_entry_types`, and structured `next_actions`.
+Each action contains a stable `code` and concrete `parameters`. Any nonempty
+warning list means a consumer must not conclude that a problem is absent.
+
+```python
+result = read_family_evidence("abc123")
+quality = result["evidence_quality"]
+
+for action in quality["next_actions"]:
+    if action["code"] == "retry_with_higher_limit":
+        result = read_family_evidence(
+            result["family_hash"],
+            limit=action["parameters"]["limit"],
+        )
+
+if result["status"] != "ok" or result["evidence_quality"]["status"] != "complete":
+    # Report the warning and next action; do not emit a passing diagnosis.
+    raise RuntimeError("Orbit evidence needs recovery before evaluation")
+```
+
+A `complete` result only describes normalized `request`, `query`, and
+`exception` fields in the returned window. Ignore rules, disabled watchers, sampling, or retention may still mean historical events
+were never captured or are no longer stored.
+
+### Action Catalog
+
+| Action code | Parameters | What the consumer should do |
+|-------------|------------|-----------------------------|
+| `provide_valid_family_hash` | `max_chars` | Obtain the full hash from `get_recent_requests` or a captured request |
+| `use_valid_limit` | `minimum`, `maximum`, `default` | Retry inside the documented bounds |
+| `verify_family_hash` | none | Confirm that the full, unshortened hash was supplied |
+| `verify_capture_and_retention` | none | Check watcher settings, ignore rules, pruning, and retention |
+| `verify_migrations_and_storage` | none | Run Orbit migrations for the configured storage alias |
+| `retry_read` | none | Retry the same read after storage recovers |
+| `inspect_server_logs` | none | Inspect the host application's logs for the internal read failure |
+| `retry_with_higher_limit` | `limit` | Repeat `read_family_evidence` with the supplied limit |
+| `call_mcp_tool` | `tool`, `arguments`, `reason` | Invoke the named MCP tool with the supplied complete argument object |
+| `review_missing_fields` | `fields` | Treat the listed measurements as unknown and review capture configuration |
+| `review_truncated_fields` | `fields` | Avoid decisions that require the clipped values |
+| `do_not_conclude_absence` | none | Do not report a passing or absent diagnosis from this response |
+
+### Evidence Quality Fragment
+
+```json
+{
+  "status": "ok",
+  "reason": null,
+  "evidence_quality": {
+    "status": "partial",
+    "warnings": ["unsupported_entry_types"],
+    "missing_fields": [],
+    "truncated_fields": [],
+    "unsupported_entry_types": ["log"],
+    "next_actions": [
+      {
+        "code": "call_mcp_tool",
+        "parameters": {
+          "tool": "create_incident_bundle",
+          "arguments": {
+            "source_type": "family_hash",
+            "source_value": "abc123",
+            "format": "json"
+          },
+          "reason": "unsupported_entry_types"
+        }
+      },
+      {"code": "do_not_conclude_absence", "parameters": {}}
+    ]
+  }
+}
+```
+
+For `not_found`, `invalid`, and `unavailable`, the same quality object uses
+`status: "unavailable"` and returns the recovery actions listed above. Surface
+the reason to the developer; never translate it into "no problem found".
+
+## Entry Schema
+
+Normalized attributes by entry type:
+
+| Entry type | Attributes |
+|------------|------------|
+| `request` | `method`, `path`, `status_code`, `query_count`, `duplicate_query_count`, `had_exception` |
+| `query` | `is_slow`, `is_duplicate`, `duplicate_count`, `database` |
+| `exception` | `exception_type`, `request_method`, `request_path` |
+| Other | Empty object; the family quality becomes `partial` and lists the type in `unsupported_entry_types` |
+
+Missing or malformed values are `null`. Valid zero values remain zero. This
+distinction matters for automated verification: unknown data is not a passing
+measurement.
+
+## Limits and Ordering
+
+```python
+evidence = read_family_evidence("abc123", limit=250)
+```
+
+- Default limit: `1000`
+- Valid range: `1..5000`
+- Ordering: `created_at`, then entry ID
+- Long paths are limited to 2,048 characters
+- Family hashes and fingerprints are limited to 64 characters
+- Other normalized strings are limited to 255 characters
+- Query strings and URL fragments are removed from paths
+- Clipped fields are listed in both the entry and quality metadata
+
+If `truncated` is true, retry with a higher limit. If the family remains
+truncated at `5000`, follow the returned `call_mcp_tool` action for
+`create_incident_bundle` and treat it as not fully evaluable instead of assuming omitted evidence is
+irrelevant. Invalid limits are rejected rather than silently clamped.
+
+## Safety Boundary
+
+Version 1 never returns:
+
+- raw payloads;
+- summaries or tags;
+- request headers, cookies, bodies, query strings, or URL fragments;
+- SQL text or parameters;
+- exception messages, tracebacks, or locals;
+- log messages;
+- mail, cache, storage, user, or session values.
+
+Endpoint paths, exception class names, database aliases, timestamps, IDs, and
+fingerprints can still be sensitive in some applications. Review your
+environment and access policy before exporting Evidence API output.
+
+The adapter performs no writes and returns a structured unavailable state
+instead of propagating storage errors into the host application. Callers must
+still branch on `status` and `evidence_quality.status`.
+
+## Compatibility
+
+Fields may be added to `orbit.evidence.v1`. Consumers must ignore unknown
+fields. Existing fields will not be removed, renamed, or given a different
+meaning within v1. A breaking change requires a new schema identifier such as
+`orbit.evidence.v2`.
+
+Import the API from `orbit.evidence`; importing private helpers from
+`orbit.agentic`, `orbit.watchers`, or the model manager is not a stable
+integration contract.

--- a/docs/security.md
+++ b/docs/security.md
@@ -37,6 +37,24 @@ Be careful with sensitive data in:
 - Request bodies (passwords, PII)
 - SQL queries (personal data)
 
+### Evidence API Safety
+
+`orbit.evidence.v1` is metadata-first and omits raw payloads, summaries, tags,
+SQL, parameters, request headers and bodies, exception messages, tracebacks,
+and logs.
+
+The remaining metadata can still reveal endpoint paths, exception class names,
+database aliases, timestamps, IDs, and fingerprints. Treat the output as
+sensitive debugging data and restrict access accordingly.
+
+A top-level status other than `ok`, `evidence_quality.status` other than
+`complete`, `truncated: true`, `null` measurements, or nonempty
+`truncated_fields` indicate incomplete evidence. Automated tools and coding
+agents must follow `evidence_quality.next_actions` and must not interpret
+missing evidence as a successful check.
+
+See [Evidence API](evidence-api.md) for the complete contract.
+
 ## Reporting Security Issues
 
 If you discover a security vulnerability, please email us directly instead of opening a public issue.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
     - Running Demo: running-demo.md
   - Reference:
     - API: api.md
+    - Evidence API: evidence-api.md
     - Customization: customization.md
   - Development:
     - Contributing: contributing.md

--- a/orbit/evidence.py
+++ b/orbit/evidence.py
@@ -1,0 +1,451 @@
+"""
+Versioned, metadata-first access to normalized Orbit evidence.
+
+This module is the public read boundary for integrations. It intentionally
+returns plain dictionaries instead of ORM objects and never includes raw
+payloads, summaries, tags, SQL, messages, headers, bodies, or tracebacks.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+from urllib.parse import urlsplit
+
+from orbit.backends import get_storage_db_alias
+from orbit.models import OrbitEntry
+from orbit.watchers import _table_exists, cachalot_disabled
+
+logger = logging.getLogger(__name__)
+
+EVIDENCE_SCHEMA_VERSION = "orbit.evidence.v1"
+DEFAULT_FAMILY_LIMIT = 1000
+MAX_FAMILY_LIMIT = 5000
+MAX_STRING_CHARS = 255
+MAX_PATH_CHARS = 2048
+
+_REQUIRED_ATTRIBUTES = {
+    OrbitEntry.TYPE_REQUEST: (
+        "method",
+        "path",
+        "status_code",
+        "query_count",
+        "duplicate_query_count",
+        "had_exception",
+    ),
+    OrbitEntry.TYPE_QUERY: (
+        "is_slow",
+        "is_duplicate",
+        "duplicate_count",
+        "database",
+    ),
+    OrbitEntry.TYPE_EXCEPTION: (
+        "exception_type",
+        "request_method",
+        "request_path",
+    ),
+}
+
+_REASON_ACTIONS = {
+    "family_not_found": ("verify_family_hash", "verify_capture_and_retention"),
+    "storage_unavailable": ("verify_migrations_and_storage",),
+    "read_failed": ("retry_read", "inspect_server_logs"),
+}
+
+__all__ = [
+    "DEFAULT_FAMILY_LIMIT",
+    "EVIDENCE_SCHEMA_VERSION",
+    "MAX_FAMILY_LIMIT",
+    "read_family_evidence",
+    "serialize_entry",
+]
+
+
+def _bounded_string(
+    value: Any,
+    field: str,
+    truncated_fields: list[str],
+    *,
+    max_chars: int = MAX_STRING_CHARS,
+) -> str | None:
+    if not isinstance(value, str):
+        return None
+    if len(value) <= max_chars:
+        return value
+    truncated_fields.append(field)
+    return value[:max_chars]
+
+
+def _path_string(
+    value: Any,
+    field: str,
+    truncated_fields: list[str],
+) -> str | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        path = urlsplit(value).path
+    except ValueError:
+        return None
+    if not path:
+        return None
+    return _bounded_string(
+        path,
+        field,
+        truncated_fields,
+        max_chars=MAX_PATH_CHARS,
+    )
+
+
+def _bounded_identifier(
+    value: Any,
+    field: str,
+    truncated_fields: list[str],
+) -> str | None:
+    if not isinstance(value, str) or not value or not value.isprintable():
+        return None
+    if any(character.isspace() for character in value):
+        return None
+    if len(value) > 64:
+        truncated_fields.append(field)
+        return value[:64]
+    return value
+
+
+def _safe_family_hash(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    if (
+        not value
+        or len(value) > 64
+        or not value.isprintable()
+        or any(character.isspace() for character in value)
+    ):
+        return None
+    return value
+
+
+def _non_negative_int(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _strict_bool(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _finite_number(value: Any) -> int | float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return value if math.isfinite(value) else None
+
+
+def _request_attributes(
+    payload: dict[str, Any], truncated_fields: list[str]
+) -> dict[str, Any]:
+    return {
+        "method": _bounded_string(
+            payload.get("method"), "attributes.method", truncated_fields
+        ),
+        "path": _path_string(payload.get("path"), "attributes.path", truncated_fields),
+        "status_code": _non_negative_int(payload.get("status_code")),
+        "query_count": _non_negative_int(payload.get("query_count")),
+        "duplicate_query_count": _non_negative_int(
+            payload.get("duplicate_query_count")
+        ),
+        "had_exception": _strict_bool(payload.get("had_exception")),
+    }
+
+
+def _query_attributes(
+    payload: dict[str, Any], truncated_fields: list[str]
+) -> dict[str, Any]:
+    return {
+        "is_slow": _strict_bool(payload.get("is_slow")),
+        "is_duplicate": _strict_bool(payload.get("is_duplicate")),
+        "duplicate_count": _non_negative_int(payload.get("duplicate_count")),
+        "database": _bounded_string(
+            payload.get("database"), "attributes.database", truncated_fields
+        ),
+    }
+
+
+def _exception_attributes(
+    payload: dict[str, Any], truncated_fields: list[str]
+) -> dict[str, Any]:
+    return {
+        "exception_type": _bounded_string(
+            payload.get("exception_type"),
+            "attributes.exception_type",
+            truncated_fields,
+        ),
+        "request_method": _bounded_string(
+            payload.get("request_method"),
+            "attributes.request_method",
+            truncated_fields,
+        ),
+        "request_path": _path_string(
+            payload.get("request_path"),
+            "attributes.request_path",
+            truncated_fields,
+        ),
+    }
+
+
+def serialize_entry(entry: OrbitEntry) -> dict[str, Any]:
+    """
+    Normalize one Orbit entry into the stable ``orbit.evidence.v1`` schema.
+
+    Missing or malformed values remain ``None`` so consumers cannot interpret
+    absent evidence as a successful zero value.
+    """
+    payload = entry.payload if isinstance(entry.payload, dict) else {}
+    truncated_fields: list[str] = []
+
+    if entry.type == OrbitEntry.TYPE_REQUEST:
+        attributes = _request_attributes(payload, truncated_fields)
+    elif entry.type == OrbitEntry.TYPE_QUERY:
+        attributes = _query_attributes(payload, truncated_fields)
+    elif entry.type == OrbitEntry.TYPE_EXCEPTION:
+        attributes = _exception_attributes(payload, truncated_fields)
+    else:
+        attributes = {}
+
+    return {
+        "id": str(entry.id),
+        "type": entry.type,
+        "family_hash": _bounded_identifier(
+            entry.family_hash, "family_hash", truncated_fields
+        ),
+        "fingerprint": _bounded_identifier(
+            entry.fingerprint, "fingerprint", truncated_fields
+        ),
+        "created_at": (
+            entry.created_at.isoformat()
+            if getattr(entry, "created_at", None) is not None
+            else None
+        ),
+        "duration_ms": _finite_number(entry.duration_ms),
+        "attributes": attributes,
+        "truncated_fields": truncated_fields,
+    }
+
+
+def _action(code: str, **parameters: Any) -> dict[str, Any]:
+    return {"code": code, "parameters": parameters}
+
+
+def _incident_bundle_action(family_hash: str, reason: str) -> dict[str, Any]:
+    return _action(
+        "call_mcp_tool",
+        tool="create_incident_bundle",
+        arguments={
+            "source_type": "family_hash",
+            "source_value": family_hash,
+            "format": "json",
+        },
+        reason=reason,
+    )
+
+
+def _unavailable_quality(reason: str | None) -> dict[str, Any]:
+    if reason == "invalid_family_hash":
+        next_actions = [_action("provide_valid_family_hash", max_chars=64)]
+    elif reason == "invalid_limit":
+        next_actions = [
+            _action(
+                "use_valid_limit",
+                minimum=1,
+                maximum=MAX_FAMILY_LIMIT,
+                default=DEFAULT_FAMILY_LIMIT,
+            )
+        ]
+    else:
+        next_actions = [
+            _action(action_code) for action_code in _REASON_ACTIONS.get(reason, ())
+        ]
+    next_actions.append(_action("do_not_conclude_absence"))
+    return {
+        "status": "unavailable",
+        "warnings": [reason] if reason else [],
+        "missing_fields": [],
+        "truncated_fields": [],
+        "unsupported_entry_types": [],
+        "next_actions": next_actions,
+    }
+
+
+def _evidence_quality(
+    family_hash: str,
+    entries: list[dict[str, Any]],
+    *,
+    truncated: bool,
+    limit: int,
+) -> dict[str, Any]:
+    warnings: list[str] = []
+    missing_fields: list[str] = []
+    truncated_fields: list[str] = []
+    unsupported_entry_types: list[str] = []
+    next_actions: list[dict[str, Any]] = []
+
+    if truncated:
+        warnings.append("family_truncated")
+        if limit < MAX_FAMILY_LIMIT:
+            next_limit = min(MAX_FAMILY_LIMIT, max(limit + 1, limit * 2))
+            next_actions.append(_action("retry_with_higher_limit", limit=next_limit))
+        else:
+            next_actions.append(
+                _incident_bundle_action(family_hash, "family_truncated")
+            )
+
+    for entry in entries:
+        entry_type = entry["type"]
+        attributes = entry["attributes"]
+        required_attributes = _REQUIRED_ATTRIBUTES.get(entry_type)
+        if required_attributes is None:
+            unsupported_entry_types.append(entry_type)
+        else:
+            for field in required_attributes:
+                if attributes.get(field) is None:
+                    missing_fields.append(f"{entry_type}.attributes.{field}")
+            if entry_type == OrbitEntry.TYPE_EXCEPTION and entry["fingerprint"] is None:
+                missing_fields.append("exception.fingerprint")
+        for field in entry["truncated_fields"]:
+            truncated_fields.append(f"{entry_type}.{field}")
+
+    missing_fields = sorted(set(missing_fields))
+    truncated_fields = sorted(set(truncated_fields))
+    unsupported_entry_types = sorted(set(unsupported_entry_types))
+
+    if missing_fields:
+        warnings.append("missing_fields")
+        next_actions.append(_action("review_missing_fields", fields=missing_fields))
+    if truncated_fields:
+        warnings.append("truncated_fields")
+        next_actions.append(_action("review_truncated_fields", fields=truncated_fields))
+    if unsupported_entry_types:
+        warnings.append("unsupported_entry_types")
+        next_actions.append(
+            _incident_bundle_action(family_hash, "unsupported_entry_types")
+        )
+
+    if warnings:
+        next_actions.append(_action("do_not_conclude_absence"))
+
+    return {
+        "status": "partial" if warnings else "complete",
+        "warnings": warnings,
+        "missing_fields": missing_fields,
+        "truncated_fields": truncated_fields,
+        "unsupported_entry_types": unsupported_entry_types,
+        "next_actions": next_actions,
+    }
+
+
+def _envelope(
+    family_hash: Any,
+    *,
+    status: str,
+    reason: str | None,
+    entries: list[dict[str, Any]] | None = None,
+    truncated: bool = False,
+    limit: int = DEFAULT_FAMILY_LIMIT,
+) -> dict[str, Any]:
+    safe_entries = entries or []
+    quality = (
+        _evidence_quality(
+            _safe_family_hash(family_hash),
+            safe_entries,
+            truncated=truncated,
+            limit=limit,
+        )
+        if status == "ok"
+        else _unavailable_quality(reason)
+    )
+    return {
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "status": status,
+        "reason": reason,
+        "family_hash": _safe_family_hash(family_hash),
+        "count": len(safe_entries),
+        "truncated": truncated,
+        "evidence_quality": quality,
+        "entries": safe_entries,
+    }
+
+
+def read_family_evidence(
+    family_hash: str,
+    *,
+    limit: int = DEFAULT_FAMILY_LIMIT,
+) -> dict[str, Any]:
+    """
+    Read one request family through a deterministic, fail-silent adapter.
+
+    The function performs no writes. Storage and ORM failures return a stable
+    ``unavailable`` envelope rather than propagating into the host application.
+    """
+    if _safe_family_hash(family_hash) is None:
+        return _envelope(
+            family_hash,
+            status="invalid",
+            reason="invalid_family_hash",
+            limit=limit,
+        )
+    if (
+        isinstance(limit, bool)
+        or not isinstance(limit, int)
+        or not 1 <= limit <= MAX_FAMILY_LIMIT
+    ):
+        return _envelope(
+            family_hash,
+            status="invalid",
+            reason="invalid_limit",
+            limit=DEFAULT_FAMILY_LIMIT,
+        )
+    if not _table_exists():
+        return _envelope(
+            family_hash,
+            status="unavailable",
+            reason="storage_unavailable",
+            limit=limit,
+        )
+
+    try:
+        alias = get_storage_db_alias()
+        queryset = (
+            OrbitEntry.objects.using(alias)
+            .filter(family_hash=family_hash)
+            .order_by("created_at", "id")[: limit + 1]
+        )
+        with cachalot_disabled():
+            records = list(queryset)
+    except Exception:
+        logger.warning("Django Orbit evidence read failed.")
+        return _envelope(
+            family_hash,
+            status="unavailable",
+            reason="read_failed",
+            limit=limit,
+        )
+
+    if not records:
+        return _envelope(
+            family_hash,
+            status="not_found",
+            reason="family_not_found",
+            limit=limit,
+        )
+
+    truncated = len(records) > limit
+    entries = [serialize_entry(entry) for entry in records[:limit]]
+    return _envelope(
+        family_hash,
+        status="ok",
+        reason=None,
+        entries=entries,
+        truncated=truncated,
+        limit=limit,
+    )

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,408 @@
+import json
+from contextlib import contextmanager
+from copy import deepcopy
+from unittest.mock import patch
+
+import pytest
+
+from orbit.models import OrbitEntry
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def evidence_family():
+    request = OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_REQUEST,
+        family_hash="family-evidence",
+        duration_ms=125.5,
+        tags=",secret-tag,",
+        payload={
+            "method": "POST",
+            "path": "/checkout/?token=secret",
+            "full_path": "/checkout/?token=secret",
+            "status_code": 500,
+            "query_count": 0,
+            "duplicate_query_count": 2,
+            "had_exception": True,
+            "headers": {"Authorization": "Bearer secret"},
+            "body": {"password": "secret"},
+        },
+    )
+    query = OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_QUERY,
+        family_hash="family-evidence",
+        duration_ms=850.0,
+        payload={
+            "is_slow": True,
+            "is_duplicate": False,
+            "duplicate_count": 0,
+            "database": "default",
+            "sql": "SELECT secret FROM payments",
+            "params": ["secret"],
+        },
+    )
+    exception = OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_EXCEPTION,
+        family_hash="family-evidence",
+        fingerprint="abc123",
+        payload={
+            "exception_type": "ValueError",
+            "request_method": "POST",
+            "request_path": "/checkout/?token=secret",
+            "message": "secret",
+            "traceback_string": "secret traceback",
+        },
+    )
+    return request, query, exception
+
+
+def test_serialize_entry_exposes_only_normalized_request_metadata(evidence_family):
+    from orbit.evidence import EVIDENCE_SCHEMA_VERSION, serialize_entry
+
+    request = evidence_family[0]
+    original_payload = deepcopy(request.payload)
+
+    data = serialize_entry(request)
+
+    assert EVIDENCE_SCHEMA_VERSION == "orbit.evidence.v1"
+    assert data == {
+        "id": str(request.id),
+        "type": "request",
+        "family_hash": "family-evidence",
+        "fingerprint": None,
+        "created_at": request.created_at.isoformat(),
+        "duration_ms": 125.5,
+        "attributes": {
+            "method": "POST",
+            "path": "/checkout/",
+            "status_code": 500,
+            "query_count": 0,
+            "duplicate_query_count": 2,
+            "had_exception": True,
+        },
+        "truncated_fields": [],
+    }
+    assert request.payload == original_payload
+    encoded = json.dumps(data)
+    assert "secret" not in encoded
+    assert "summary" not in data
+    assert "tags" not in data
+
+
+def test_serialize_entry_normalizes_query_and_exception(evidence_family):
+    from orbit.evidence import serialize_entry
+
+    query = serialize_entry(evidence_family[1])
+    exception = serialize_entry(evidence_family[2])
+
+    assert query["attributes"] == {
+        "is_slow": True,
+        "is_duplicate": False,
+        "duplicate_count": 0,
+        "database": "default",
+    }
+    assert exception["fingerprint"] == "abc123"
+    assert exception["attributes"] == {
+        "exception_type": "ValueError",
+        "request_method": "POST",
+        "request_path": "/checkout/",
+    }
+    assert "secret" not in json.dumps([query, exception])
+
+
+def test_serialize_entry_preserves_unknowns_as_none(db):
+    from orbit.evidence import serialize_entry
+
+    entry = OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_REQUEST,
+        family_hash="family-missing",
+        payload={
+            "method": 123,
+            "status_code": True,
+            "query_count": -1,
+            "duplicate_query_count": "2",
+            "had_exception": 1,
+        },
+    )
+
+    assert serialize_entry(entry)["attributes"] == {
+        "method": None,
+        "path": None,
+        "status_code": None,
+        "query_count": None,
+        "duplicate_query_count": None,
+        "had_exception": None,
+    }
+
+
+def test_serialize_entry_bounds_strings_and_unknown_types(db):
+    from orbit.evidence import serialize_entry
+
+    request = OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_REQUEST,
+        family_hash="family-long",
+        payload={"method": "M" * 300, "path": "/" + ("x" * 3000)},
+    )
+    log = OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_LOG,
+        family_hash="family-long",
+        payload={"message": "secret"},
+    )
+
+    request_data = serialize_entry(request)
+    log_data = serialize_entry(log)
+
+    assert len(request_data["attributes"]["method"]) == 255
+    assert len(request_data["attributes"]["path"]) == 2048
+    assert request_data["truncated_fields"] == [
+        "attributes.method",
+        "attributes.path",
+    ]
+    assert log_data["attributes"] == {}
+    assert "secret" not in json.dumps(log_data)
+
+
+def test_serialize_entry_bounds_public_scalar_identifiers():
+    from orbit.evidence import serialize_entry
+
+    entry = OrbitEntry(
+        type=OrbitEntry.TYPE_EXCEPTION,
+        family_hash="invalid\nhash",
+        fingerprint="f" * 100,
+        payload={
+            "exception_type": "ValueError",
+            "request_method": "GET",
+            "request_path": "/failure/",
+        },
+    )
+
+    data = serialize_entry(entry)
+
+    assert data["family_hash"] is None
+    assert data["fingerprint"] == "f" * 64
+    assert data["truncated_fields"] == ["fingerprint"]
+
+
+def test_read_family_evidence_returns_deterministic_bounded_envelope(evidence_family):
+    from orbit.evidence import read_family_evidence
+
+    data = read_family_evidence("family-evidence", limit=2)
+
+    assert data["schema_version"] == "orbit.evidence.v1"
+    assert data["status"] == "ok"
+    assert data["reason"] is None
+    assert data["family_hash"] == "family-evidence"
+    assert data["count"] == 2
+    assert data["truncated"] is True
+    assert data["evidence_quality"]["status"] == "partial"
+    assert data["evidence_quality"]["warnings"] == ["family_truncated"]
+    assert data["evidence_quality"]["next_actions"] == [
+        {"code": "retry_with_higher_limit", "parameters": {"limit": 4}},
+        {"code": "do_not_conclude_absence", "parameters": {}},
+    ]
+    assert [item["id"] for item in data["entries"]] == [
+        str(evidence_family[0].id),
+        str(evidence_family[1].id),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("family_hash", "limit", "reason"),
+    [
+        ("", 10, "invalid_family_hash"),
+        (" " * 3, 10, "invalid_family_hash"),
+        (123, 10, "invalid_family_hash"),
+        ("x" * 65, 10, "invalid_family_hash"),
+        ("family\nhash", 10, "invalid_family_hash"),
+        ("family", 0, "invalid_limit"),
+        ("family", True, "invalid_limit"),
+        ("family", 5001, "invalid_limit"),
+    ],
+)
+def test_read_family_evidence_rejects_invalid_inputs(family_hash, limit, reason):
+    from orbit.evidence import read_family_evidence
+
+    data = read_family_evidence(family_hash, limit=limit)
+
+    assert data["status"] == "invalid"
+    assert data["reason"] == reason
+    assert data["entries"] == []
+    assert data["evidence_quality"]["status"] == "unavailable"
+    assert "do_not_conclude_absence" in {
+        action["code"] for action in data["evidence_quality"]["next_actions"]
+    }
+    if reason == "invalid_family_hash":
+        assert data["family_hash"] is None
+
+
+def test_read_family_evidence_reports_not_found(db):
+    from orbit.evidence import read_family_evidence
+
+    data = read_family_evidence("missing-family")
+
+    assert data["status"] == "not_found"
+    assert data["reason"] == "family_not_found"
+    assert data["count"] == 0
+    assert data["truncated"] is False
+    assert data["evidence_quality"]["warnings"] == ["family_not_found"]
+    assert data["evidence_quality"]["next_actions"] == [
+        {"code": "verify_family_hash", "parameters": {}},
+        {"code": "verify_capture_and_retention", "parameters": {}},
+        {"code": "do_not_conclude_absence", "parameters": {}},
+    ]
+
+
+def test_read_family_evidence_fails_silently_when_storage_is_unavailable(db):
+    from orbit.evidence import read_family_evidence
+
+    with patch("orbit.evidence._table_exists", return_value=False):
+        data = read_family_evidence("family")
+
+    assert data["status"] == "unavailable"
+    assert data["reason"] == "storage_unavailable"
+    assert data["evidence_quality"]["next_actions"] == [
+        {"code": "verify_migrations_and_storage", "parameters": {}},
+        {"code": "do_not_conclude_absence", "parameters": {}},
+    ]
+
+
+def test_read_family_evidence_fails_silently_on_database_error(db):
+    from orbit.evidence import read_family_evidence
+
+    with (
+        patch("orbit.evidence._table_exists", return_value=True),
+        patch("orbit.evidence.OrbitEntry.objects.using", side_effect=RuntimeError),
+    ):
+        data = read_family_evidence("family")
+
+    assert data["status"] == "unavailable"
+    assert data["reason"] == "read_failed"
+    assert data["evidence_quality"]["next_actions"] == [
+        {"code": "retry_read", "parameters": {}},
+        {"code": "inspect_server_logs", "parameters": {}},
+        {"code": "do_not_conclude_absence", "parameters": {}},
+    ]
+
+
+def test_read_family_evidence_marks_missing_metadata_as_partial(db):
+    from orbit.evidence import read_family_evidence
+
+    OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_REQUEST,
+        family_hash="family-partial",
+        payload={"method": "GET", "path": "/health/"},
+    )
+
+    data = read_family_evidence("family-partial")
+
+    assert data["status"] == "ok"
+    assert data["evidence_quality"]["status"] == "partial"
+    assert data["evidence_quality"]["warnings"] == ["missing_fields"]
+    assert data["evidence_quality"]["missing_fields"] == [
+        "request.attributes.duplicate_query_count",
+        "request.attributes.had_exception",
+        "request.attributes.query_count",
+        "request.attributes.status_code",
+    ]
+    assert data["evidence_quality"]["next_actions"] == [
+        {
+            "code": "review_missing_fields",
+            "parameters": {"fields": data["evidence_quality"]["missing_fields"]},
+        },
+        {"code": "do_not_conclude_absence", "parameters": {}},
+    ]
+
+
+def test_read_family_evidence_marks_unsupported_types_as_partial(db):
+    from orbit.evidence import read_family_evidence
+
+    OrbitEntry.objects.create(
+        type=OrbitEntry.TYPE_LOG,
+        family_hash="family-log",
+        payload={"message": "not exposed"},
+    )
+
+    data = read_family_evidence("family-log")
+
+    assert data["status"] == "ok"
+    assert data["evidence_quality"]["status"] == "partial"
+    assert data["evidence_quality"]["warnings"] == ["unsupported_entry_types"]
+    assert data["evidence_quality"]["unsupported_entry_types"] == ["log"]
+    assert data["evidence_quality"]["next_actions"] == [
+        {
+            "code": "call_mcp_tool",
+            "parameters": {
+                "tool": "create_incident_bundle",
+                "arguments": {
+                    "source_type": "family_hash",
+                    "source_value": "family-log",
+                    "format": "json",
+                },
+                "reason": "unsupported_entry_types",
+            },
+        },
+        {"code": "do_not_conclude_absence", "parameters": {}},
+    ]
+
+
+def test_read_family_evidence_routes_maximum_truncation_to_incident_bundle(db):
+    from orbit.evidence import MAX_FAMILY_LIMIT, read_family_evidence
+
+    OrbitEntry.objects.bulk_create(
+        [
+            OrbitEntry(
+                type=OrbitEntry.TYPE_LOG,
+                family_hash="family-oversized",
+                payload={},
+            )
+            for _ in range(MAX_FAMILY_LIMIT + 1)
+        ]
+    )
+
+    data = read_family_evidence("family-oversized", limit=MAX_FAMILY_LIMIT)
+
+    assert data["truncated"] is True
+    assert data["evidence_quality"]["next_actions"][0] == {
+        "code": "call_mcp_tool",
+        "parameters": {
+            "tool": "create_incident_bundle",
+            "arguments": {
+                "source_type": "family_hash",
+                "source_value": "family-oversized",
+                "format": "json",
+            },
+            "reason": "family_truncated",
+        },
+    }
+
+
+def test_read_family_evidence_uses_storage_alias_and_disables_cache(evidence_family):
+    from orbit.evidence import read_family_evidence
+
+    calls = []
+
+    @contextmanager
+    def cache_disabled():
+        calls.append("entered")
+        yield
+        calls.append("exited")
+
+    with (
+        patch("orbit.evidence._table_exists", return_value=True),
+        patch("orbit.evidence.get_storage_db_alias", return_value="default") as alias,
+        patch("orbit.evidence.cachalot_disabled", cache_disabled),
+    ):
+        data = read_family_evidence("family-evidence")
+
+    alias.assert_called_once_with()
+    assert calls == ["entered", "exited"]
+    assert data["status"] == "ok"
+    assert data["evidence_quality"] == {
+        "status": "complete",
+        "warnings": [],
+        "missing_fields": [],
+        "truncated_fields": [],
+        "unsupported_entry_types": [],
+        "next_actions": [],
+    }


### PR DESCRIPTION
## Summary

- add the public `orbit.evidence.v1` read boundary for integrations and future Orbit Pro consumers
- return metadata-first normalized request-family evidence without raw payloads, SQL, headers, bodies, messages, or tracebacks
- distinguish read status from evidence completeness and provide structured, executable recovery actions for coding agents
- strip query strings and fragments, bound public identifiers, honor the configured storage alias, and fail without affecting the host app
- document the schema, action catalog, security boundary, compatibility policy, and safe consumption flow

## Verification

- `python -m pytest --tb=short -q` -> 302 passed, 1 skipped
- `python -m pytest tests/test_evidence.py -q` -> 21 passed
- Black and isort checks pass for the new Python files
- Python 3.9 grammar parse passes
- `python -m mkdocs build --strict` passes
- package build and `twine check` pass
- independent correctness/security review: no P0/P1/P2 findings
- independent developer/agent UX review: pass, no P0/P1 findings

## Integration note

This branch is based on `release/v0.13.0` at `0ae9d33`. There is separate unpublished AI-first work in progress outside this branch. Recheck and rebase this PR after that work is committed; do not overwrite those changes.